### PR TITLE
NIAD-778 Fixes a bug that would produce duplicate operation ids if GP and HA transaction numbers intersect

### DIFF
--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
@@ -55,9 +55,9 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
     private static final ReferenceTransactionType.Inbound MESSAGE_2_TRANSACTION_TYPE = ReferenceTransactionType.Inbound.DEDUCTION;
     private static final ReferenceTransactionType.Inbound MESSAGE_3_TRANSACTION_TYPE = ReferenceTransactionType.Inbound.REJECTION;
     private static final ReferenceTransactionType.Inbound MESSAGE_4_TRANSACTION_TYPE = ReferenceTransactionType.Inbound.APPROVAL;
-    private static final String TRANSACTION_1_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_1);
-    private static final String TRANSACTION_2_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_2);
-    private static final String TRANSACTION_3_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_3);
+    private static final String TRANSACTION_1_OPERATION_ID = OperationId.buildOperationId(SENDER, TN_1);
+    private static final String TRANSACTION_2_OPERATION_ID = OperationId.buildOperationId(SENDER, TN_2);
+    private static final String TRANSACTION_3_OPERATION_ID = OperationId.buildOperationId(SENDER, TN_3);
     private static final String TRANSACTION_4_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_4);
     private static final String TRANSACTION_5_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_5);
     private static final String TRANSACTION_6_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_6);

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdService.java
@@ -5,21 +5,25 @@ import uk.nhs.digital.nhsconnect.nhais.model.edifact.ReferenceTransactionType;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.utils.OperationId;
 
-import java.util.List;
+import java.util.Set;
 
 @Service
 public class InboundOperationIdService {
 
-    private static final List<ReferenceTransactionType.TransactionType> MAPPED_BY_TRANSACTION_NUMBER =
-            List.of(ReferenceTransactionType.Inbound.APPROVAL, ReferenceTransactionType.Inbound.REJECTION);
+    private static final Set<ReferenceTransactionType.TransactionType> MATCHED_BY_TRANSACTION_NUMBER =
+            Set.of(ReferenceTransactionType.Inbound.APPROVAL, ReferenceTransactionType.Inbound.REJECTION);
 
     public String createOperationIdForTransaction(Transaction transaction) {
         final String tradingPartnerCode;
         final var transactionType = transaction.getMessage().getReferenceTransactionType().getTransactionType();
         final var transactionNumber = transaction.getReferenceTransactionNumber().getTransactionNumber();
-        if (MAPPED_BY_TRANSACTION_NUMBER.contains(transactionType)) {
+        if (MATCHED_BY_TRANSACTION_NUMBER.contains(transactionType)) {
+            // inbound transactions matched to the outbound transaction by their transaction number use recipient
+            // trading partner code to ensure the same OperationId is generated
             tradingPartnerCode = transaction.getMessage().getInterchange().getInterchangeHeader().getRecipient();
         } else {
+            // inbound transactions not matched to an outbound transaction by transaction number use sender
+            // trading partner code to ensure the OperationId is unique
             tradingPartnerCode = transaction.getMessage().getInterchange().getInterchangeHeader().getSender();
         }
         return OperationId.buildOperationId(tradingPartnerCode, transactionNumber);

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdService.java
@@ -1,0 +1,27 @@
+package uk.nhs.digital.nhsconnect.nhais.inbound;
+
+import org.springframework.stereotype.Service;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.ReferenceTransactionType;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
+import uk.nhs.digital.nhsconnect.nhais.utils.OperationId;
+
+import java.util.List;
+
+@Service
+public class InboundOperationIdService {
+
+    private static final List<ReferenceTransactionType.TransactionType> MAPPED_BY_TRANSACTION_NUMBER =
+            List.of(ReferenceTransactionType.Inbound.APPROVAL, ReferenceTransactionType.Inbound.REJECTION);
+
+    public String createOperationIdForTransaction(Transaction transaction) {
+        final String tradingPartnerCode;
+        final var transactionType = transaction.getMessage().getReferenceTransactionType().getTransactionType();
+        final var transactionNumber = transaction.getReferenceTransactionNumber().getTransactionNumber();
+        if (MAPPED_BY_TRANSACTION_NUMBER.contains(transactionType)) {
+            tradingPartnerCode = transaction.getMessage().getInterchange().getInterchangeHeader().getRecipient();
+        } else {
+            tradingPartnerCode = transaction.getMessage().getInterchange().getInterchangeHeader().getSender();
+        }
+        return OperationId.buildOperationId(tradingPartnerCode, transactionNumber);
+    }
+}

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/RegistrationConsumerService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/RegistrationConsumerService.java
@@ -43,6 +43,7 @@ public class RegistrationConsumerService {
     private final RecepProducerService recepProducerService;
     private final EdifactParser edifactParser;
     private final InboundEdifactTransactionHandler inboundEdifactTransactionService;
+    private final InboundOperationIdService inboundOperationIdService;
 
     public void handleRegistration(InboundMeshMessage meshMessage) {
         Interchange interchange = edifactParser.parse(meshMessage.getContent());
@@ -128,9 +129,7 @@ public class RegistrationConsumerService {
             .map(transaction -> {
                 var dataToSend = inboundEdifactTransactionService.translate(transaction);
                 LOGGER.debug("Converted registration message into {}", dataToSend.getContent());
-                var operationId = OperationId.buildOperationId(
-                    transaction.getMessage().getInterchange().getInterchangeHeader().getRecipient(),
-                    transaction.getReferenceTransactionNumber().getTransactionNumber());
+                var operationId = inboundOperationIdService.createOperationIdForTransaction(transaction);
                 logTransactionReceived(transaction, operationId);
                 return dataToSend
                     .setOperationId(operationId)

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactory.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactory.java
@@ -3,6 +3,7 @@ package uk.nhs.digital.nhsconnect.nhais.inbound.state;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import uk.nhs.digital.nhsconnect.nhais.inbound.InboundOperationIdService;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.WorkflowId;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Message;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.ReferenceTransactionType;
@@ -17,6 +18,7 @@ public class InboundStateFactory {
 
     private final TimestampService timestampService;
     private final ConversationIdService conversationIdService;
+    private final InboundOperationIdService inboundOperationIdService;
 
     public InboundState fromTransaction(Transaction transaction) {
         var interchangeHeader = transaction.getMessage().getInterchange().getInterchangeHeader();
@@ -30,7 +32,7 @@ public class InboundStateFactory {
 
         return new InboundState()
             .setWorkflowId(WorkflowId.REGISTRATION)
-            .setOperationId(OperationId.buildOperationId(recipient, transactionNumber))
+            .setOperationId(inboundOperationIdService.createOperationIdForTransaction(transaction))
             .setSender(interchangeHeader.getSender())
             .setRecipient(recipient)
             .setInterchangeSequence(interchangeHeader.getSequenceNumber())

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdServiceTest.java
@@ -1,0 +1,70 @@
+package uk.nhs.digital.nhsconnect.nhais.inbound;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.*;
+import uk.nhs.digital.nhsconnect.nhais.utils.OperationId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class InboundOperationIdServiceTest {
+
+    private static final Long TN = 15783L;
+    private static final String SENDER = "SEN1";
+    private static final String RECIPIENT = "REC1";
+    private static final String SENDER_OID = OperationId.buildOperationId(SENDER, TN);
+    private static final String RECIPIENT_OID = OperationId.buildOperationId(RECIPIENT, TN);
+
+    private final InboundOperationIdService operationIdService = new InboundOperationIdService();
+
+    @Mock
+    private Transaction transaction;
+
+    @Mock
+    private Message message;
+
+    @Mock
+    private Interchange interchange;
+
+    @Mock
+    private InterchangeHeader interchangeHeader;
+
+    @Mock
+    private ReferenceTransactionNumber referenceTransactionNumber;
+
+    @Mock
+    private ReferenceTransactionType referenceTransactionType;
+
+    @BeforeEach
+    private void beforeEach() {
+        when(transaction.getMessage()).thenReturn(message);
+        when(transaction.getReferenceTransactionNumber()).thenReturn(referenceTransactionNumber);
+        when(message.getInterchange()).thenReturn(interchange);
+        when(message.getReferenceTransactionType()).thenReturn(referenceTransactionType);
+        when(interchange.getInterchangeHeader()).thenReturn(interchangeHeader);
+        when(referenceTransactionNumber.getTransactionNumber()).thenReturn(TN);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ReferenceTransactionType.Inbound.class, names = {"APPROVAL", "REJECTION"})
+    public void When_ApprovalOrRejectionTransaction_Then_OperationIdUsesRecipient(ReferenceTransactionType.Inbound transactionType) {
+        when(referenceTransactionType.getTransactionType()).thenReturn(transactionType);
+        when(interchangeHeader.getRecipient()).thenReturn(RECIPIENT);
+        assertThat(RECIPIENT_OID).isEqualTo(operationIdService.createOperationIdForTransaction(transaction));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ReferenceTransactionType.Inbound.class, names = {"APPROVAL", "REJECTION"}, mode = EnumSource.Mode.EXCLUDE)
+    public void When_AllOtherTransactions_Then_OperationIdUsesSender(ReferenceTransactionType.Inbound transactionType) {
+        when(referenceTransactionType.getTransactionType()).thenReturn(transactionType);
+        when(interchangeHeader.getSender()).thenReturn(SENDER);
+        assertThat(SENDER_OID).isEqualTo(operationIdService.createOperationIdForTransaction(transaction));
+    }
+
+}

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactoryTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactoryTest.java
@@ -7,6 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.digital.nhsconnect.nhais.inbound.InboundOperationIdService;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.WorkflowId;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Interchange;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.InterchangeHeader;
@@ -71,6 +72,9 @@ public class InboundStateFactoryTest {
     @Mock
     ConversationIdService conversationIdService;
 
+    @Mock
+    InboundOperationIdService inboundOperationIdService;
+
     @InjectMocks
     InboundStateFactory inboundStateFactory;
 
@@ -93,6 +97,7 @@ public class InboundStateFactoryTest {
 
     @Test
     void whenFromInterchangeCalled_thenInboundStateObjectIsCreated() {
+        when(inboundOperationIdService.createOperationIdForTransaction(TRANSACTION)).thenReturn(OPERATION_ID);
         var inboundStateFromInterchange = inboundStateFactory.fromTransaction(TRANSACTION);
         assertThat(inboundStateFromInterchange).isEqualTo(EXPECTED_INTERCHANGE_INBOUND_STATE);
     }


### PR DESCRIPTION
* The inbound OperationId is calculated...
** using recipient (gp) trading partner code for approval and rejection
** using sender (ha) trading partner code for all other inbound types
* Backwards-compatible for matching approval and rejection transactions