### PR TITLE
Update testcontainers to fix "No such image" error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
 
-    testImplementation "org.testcontainers:testcontainers:1.14.3"
+    testImplementation "org.testcontainers:testcontainers:1.15.1"
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.0.3'
     testImplementation("org.assertj:assertj-core:3.16.1")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
 
-    testImplementation "org.testcontainers:testcontainers:1.14.2"
+    testImplementation "org.testcontainers:testcontainers:1.14.3"
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.0.3'
     testImplementation("org.assertj:assertj-core:3.16.1")
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
@@ -3,7 +3,6 @@ package uk.nhs.digital.nhsconnect.nhais.outbound.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Parameters;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -119,7 +118,6 @@ public class FhirControllerTest {
         verify(outboundQueueService).publish(meshMessage);
     }
 
-    @NotNull
     private MeshMessage getMeshMessage() {
         MeshMessage meshMessage = new MeshMessage();
         meshMessage.setContent("EDI");


### PR DESCRIPTION
Getting the following errors in Jenkins:

> No such image: quay.io/testcontainers/ryuk:0.2.3
> No such image: testcontainers/ryuk:0.3.0

Version 1.14.3 includes the change:

> Move away from using quay.io for default images

Version 1.15.1 includes the fix:

> Docker 20.10 introduced a new version of the API, 1.41, where they removed quite a few deprecations, and we were using one of them. If you were getting "No such image: testcontainers/ryuk:0.3.0" - that's the cause.