### PR TITLE
NIAD-3347: Update `Java` to version `21`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Setup Java 11
+      - name: Setup Java 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: temurin
 
       - name: Execute Unit Tests
@@ -49,10 +49,10 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Setup Java 11
+      - name: Setup Java 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: temurin
 
       - name: Execute Component Tests
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: temurin
 
       - name: Setup Required Docker Images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- Update adaptor to use Java JDK 21.
+
 ## [1.4.2] - 2022-04-14
 - Hotfix for Spring vulnerability CVE-2022-22965
 - 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM gradle:jdk11 as cache
+FROM gradle:8.5-jdk21 as cache
 RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
 COPY build.gradle /home/gradle/src/
 WORKDIR /home/gradle/src
 RUN gradle -b build.gradle clean build -i --stacktrace
 
-FROM gradle:jdk11 AS build
+FROM gradle:8.5-jdk21 AS build
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle --no-daemon -b build.gradle bootJar -i --stacktrace
 
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:21-jre-jammy
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM gradle:8.5-jdk21 as cache
+FROM gradle:jdk21 as cache
 RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
 COPY build.gradle /home/gradle/src/
 WORKDIR /home/gradle/src
 RUN gradle -b build.gradle clean build -i --stacktrace
 
-FROM gradle:8.5-jdk21 AS build
+FROM gradle:jdk21 AS build
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src

--- a/Dockerfile.responder
+++ b/Dockerfile.responder
@@ -1,17 +1,17 @@
-FROM gradle:jdk11 as cache
+FROM gradle:8.5-jdk21 as cache
 RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
 COPY responder.gradle /home/gradle/src/
 WORKDIR /home/gradle/src
 RUN gradle -b responder.gradle clean build -i --stacktrace
 
-FROM gradle:jdk11 AS build
+FROM gradle:8.5-jdk21 AS build
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle --no-daemon -b responder.gradle bootJar -i --stacktrace
 
-FROM eclipse-temurin:11-jre-focal
+FROM eclipse-temurin:21-jre-jammy
 
 EXPOSE 8080
 

--- a/Dockerfile.responder
+++ b/Dockerfile.responder
@@ -1,11 +1,11 @@
-FROM gradle:8.5-jdk21 as cache
+FROM gradle:jdk21 as cache
 RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
 COPY responder.gradle /home/gradle/src/
 WORKDIR /home/gradle/src
 RUN gradle -b responder.gradle clean build -i --stacktrace
 
-FROM gradle:8.5-jdk21 AS build
+FROM gradle:jdk21 AS build
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,3 +1,3 @@
-FROM gradle:8.5-jdk21 AS build
+FROM gradle:jdk21 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,3 +1,3 @@
-FROM gradle:jdk11 AS build
+FROM gradle:8.5-jdk21 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Example: [nhais-env-example.yaml](./nhais-env-example.yaml)
 
 ### Pre-requisites (IntelliJ)
 
-* Install a Java JDK 11. [AdoptOpenJdk](https://adoptopenjdk.net/index.html?variant=openjdk11&jvmVariant=hotspot) is recommended.
+* Install a Java JDK 21. [Temurin](https://adoptium.net/en-GB/temurin/releases/) is recommended.
 * Install [IntelliJ](https://www.jetbrains.com/idea/)
 * Install the [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok)
 * Install [Docker](https://www.docker.com/products/docker-desktop)
@@ -300,9 +300,9 @@ Example: [nhais-env-example.yaml](./nhais-env-example.yaml)
 * Verify the project structure
 
 
-    Project structure -> SDKs -> add new SDK -> select adoptopenjdk-11.jdk/Contents/Home  (or alternative location)
-                      -> Project SDK -> Java 11 (11.0.7)
-                      -> Module SDK -> Java 11 (11.0.7)
+    Project structure -> SDKs -> add new SDK -> select your installed java SDK (21.x.x)
+                      -> Project SDK -> Java 21 (21.x.x)
+                      -> Module SDK -> Java 21 (21.x.x)
 
 ### Start Dependencies
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,24 @@
 plugins {
-	id "org.springframework.boot" version "2.5.12"
-	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+	id "org.springframework.boot" version "3.4.5"
+	id 'io.spring.dependency-management' version '1.1.7'
 	id 'java'
-	id "io.freefair.lombok" version "5.1.0"
+	id "io.freefair.lombok" version "8.13.1"
 	id 'jacoco'
 	id 'checkstyle'
 }
 
+apply plugin: 'java'
+apply plugin: 'application'
 apply plugin: 'checkstyle'
+apply plugin: 'org.springframework.boot'
 
-group = 'uk.nhs.digital.nhsconnect'
-version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+group = 'uk.nhs.digital.nhsconnect.nhais'
+sourceCompatibility = '21'
+
+mainClassName = 'uk.nhs.digital.nhsconnect.nhais.IntegrationAdaptorNhaisApplication'
 
 repositories {
 	mavenCentral()
-}
-
-bootJar {
-	mainClassName = 'uk.nhs.digital.nhsconnect.nhais.IntegrationAdaptorNhaisApplication'
 }
 
 sourceSets {
@@ -50,6 +50,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework:spring-jms'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.12'
 	implementation 'com.heroku.sdk:env-keystore:1.1.4'
 
@@ -57,16 +58,10 @@ dependencies {
 	implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:4.2.0'
 	implementation 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:4.2.0'
 	implementation 'com.google.guava:guava:29.0-jre'
-	implementation 'org.springframework:spring-jms:5.2.6.RELEASE'
-	implementation 'org.apache.qpid:qpid-jms-client:0.51.0'
+	implementation 'org.apache.qpid:qpid-jms-client:2.7.0'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.11.880'
 
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-
-	implementation 'org.projectlombok:lombok'
-	testImplementation 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
@@ -75,10 +70,6 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.15.1"
     testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.0.3'
     testImplementation("org.assertj:assertj-core:3.16.1")
-}
-
-lombok {
-	config['lombok.log.fieldName'] = 'LOGGER'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/IntegrationBaseTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/IntegrationBaseTest.java
@@ -27,10 +27,10 @@ import uk.nhs.digital.nhsconnect.nhais.mesh.message.OutboundMeshMessage;
 import uk.nhs.digital.nhsconnect.nhais.outbound.state.OutboundStateRepository;
 import uk.nhs.digital.nhsconnect.nhais.utils.JmsReader;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.jms.JMSException;
-import javax.jms.Message;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/DeadLetterQueueTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/DeadLetterQueueTest.java
@@ -13,7 +13,7 @@ import uk.nhs.digital.nhsconnect.nhais.outbound.OutboundQueueService;
 import uk.nhs.digital.nhsconnect.nhais.utils.ConversationIdService;
 import uk.nhs.digital.nhsconnect.nhais.utils.JmsHeaders;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
@@ -16,8 +16,8 @@ import uk.nhs.digital.nhsconnect.nhais.outbound.state.OutboundState;
 import uk.nhs.digital.nhsconnect.nhais.utils.OperationId;
 import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Instant;

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueRegistrationTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueRegistrationTest.java
@@ -16,7 +16,7 @@ import uk.nhs.digital.nhsconnect.nhais.outbound.state.OutboundState;
 import uk.nhs.digital.nhsconnect.nhais.utils.OperationId;
 import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Instant;

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundUserAcceptanceTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundUserAcceptanceTest.java
@@ -18,8 +18,8 @@ import uk.nhs.digital.nhsconnect.nhais.uat.common.InboundArgumentsProvider;
 import uk.nhs.digital.nhsconnect.nhais.uat.common.TestData;
 import uk.nhs.digital.nhsconnect.nhais.utils.JmsHeaders;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/configuration/AmqpAutoConfiguration.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/configuration/AmqpAutoConfiguration.java
@@ -10,7 +10,7 @@ import org.springframework.boot.autoconfigure.jms.JndiConnectionFactoryAutoConfi
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import javax.jms.ConnectionFactory;
+import jakarta.jms.ConnectionFactory;
 
 @Configuration
 @AutoConfigureBefore(JmsAutoConfiguration.class)

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/configuration/AmqpConfiguration.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/configuration/AmqpConfiguration.java
@@ -13,7 +13,7 @@ import org.springframework.jms.support.converter.MappingJackson2MessageConverter
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.util.StringUtils;
 
-import javax.jms.ConnectionFactory;
+import jakarta.jms.ConnectionFactory;
 
 
 @Configuration

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/configuration/ttl/TimeToLiveConfiguration.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/configuration/ttl/TimeToLiveConfiguration.java
@@ -10,7 +10,7 @@ import uk.nhs.digital.nhsconnect.nhais.configuration.NhaisMongoClientConfigurati
 import uk.nhs.digital.nhsconnect.nhais.inbound.state.InboundState;
 import uk.nhs.digital.nhsconnect.nhais.outbound.state.OutboundState;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @Component
 @Slf4j

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueService.java
@@ -18,8 +18,8 @@ import uk.nhs.digital.nhsconnect.nhais.utils.JmsHeaders;
 import uk.nhs.digital.nhsconnect.nhais.utils.JmsReader;
 import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import java.io.IOException;
 
 @Component

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/ConversationIdFilter.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/ConversationIdFilter.java
@@ -9,11 +9,11 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import uk.nhs.digital.nhsconnect.nhais.utils.ConversationIdService;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/OperationOutcomeExceptionHandler.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/OperationOutcomeExceptionHandler.java
@@ -5,7 +5,9 @@ import org.hl7.fhir.r4.model.OperationOutcome;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -40,5 +42,21 @@ public class OperationOutcomeExceptionHandler extends ResponseEntityExceptionHan
         OperationOutcome operationOutcome = OperationOutcomeUtils.createFromMessage(ex.getMessage());
         String content = fhirParser.encodeToString(operationOutcome);
         return new ResponseEntity<>(content, headers, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+        Exception ex,
+        @Nullable Object body,
+        HttpHeaders headers,
+        HttpStatusCode status,
+        WebRequest request
+    ) {
+        LOGGER.error("Creating OperationOutcome response for unhandled exception", ex);
+        headers.put(HttpHeaders.CONTENT_TYPE, singletonList("application/json"));
+        OperationOutcome operationOutcome = OperationOutcomeUtils.createFromMessage(ex.getMessage());
+        String content = fhirParser.encodeToString(operationOutcome);
+        return new ResponseEntity<>(content, headers, status);
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/OperationOutcomeExceptionHandler.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/OperationOutcomeExceptionHandler.java
@@ -41,13 +41,4 @@ public class OperationOutcomeExceptionHandler extends ResponseEntityExceptionHan
         String content = fhirParser.encodeToString(operationOutcome);
         return new ResponseEntity<>(content, headers, HttpStatus.INTERNAL_SERVER_ERROR);
     }
-
-    @Override
-    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
-        LOGGER.error("Creating OperationOutcome response for unhandled exception", ex);
-        headers.put(HttpHeaders.CONTENT_TYPE, singletonList("application/json"));
-        OperationOutcome operationOutcome = OperationOutcomeUtils.createFromMessage(ex.getMessage());
-        String content = fhirParser.encodeToString(operationOutcome);
-        return new ResponseEntity<>(content, headers, status);
-    }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/OutboundQueueService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/OutboundQueueService.java
@@ -16,8 +16,8 @@ import uk.nhs.digital.nhsconnect.nhais.utils.JmsHeaders;
 import uk.nhs.digital.nhsconnect.nhais.utils.JmsReader;
 import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import java.io.IOException;
 
 @Component

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/utils/JmsReader.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/utils/JmsReader.java
@@ -3,8 +3,8 @@ package uk.nhs.digital.nhsconnect.nhais.utils;
 import org.apache.qpid.jms.message.JmsBytesMessage;
 import org.apache.qpid.jms.message.JmsTextMessage;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 
 public class JmsReader {
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemServiceTest.java
@@ -13,9 +13,9 @@ import org.springframework.jms.core.MessageCreator;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.ReferenceTransactionType;
 import uk.nhs.digital.nhsconnect.nhais.utils.ConversationIdService;
 
-import javax.jms.JMSException;
-import javax.jms.Session;
-import javax.jms.TextMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueServiceTest.java
@@ -21,9 +21,9 @@ import uk.nhs.digital.nhsconnect.nhais.utils.ConversationIdService;
 import uk.nhs.digital.nhsconnect.nhais.utils.JmsHeaders;
 import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
 
-import javax.jms.Message;
-import javax.jms.Session;
-import javax.jms.TextMessage;
+import jakarta.jms.Message;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
 
 import java.time.Instant;
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
@@ -169,6 +169,6 @@ public class FhirControllerTest {
         verify(fhirParser).encodeToString(operationOutcomeArgumentCaptor.capture());
         var operationOutcome = operationOutcomeArgumentCaptor.getValue();
 
-        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText()).isEqualTo("Content type 'text/plain' not supported");
+        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText()).isEqualTo("Content-Type 'text/plain' is not supported");
     }
 }


### PR DESCRIPTION
Update `Java` to version `21`

* Update gradle-wrapper.properties to use gradle 8.5 (compatible with java 21)
* Update javax.* packages to jakarta.* packages.
* Remove override exception which no longer exists on super class.
* Update GitHub test workflow to use Java 21
* Update Dockerfiles to use Java 21
* Updated `handleExceptionInternal` override method to `OperationOutcomeExceptionHandler`, this now uses `HttpStatusCode` instead of `HttpStatus` so the associated test expected response text is adjusted slightly to reflect the new error message.
* Update documentation to reflect change to Java 21
* Update CHANGELOG.md