### PR TITLE
Update HAPI FHIR R4 to version `8.0.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,9 +54,9 @@ dependencies {
 	implementation 'org.apache.httpcomponents:httpclient:4.5.12'
 	implementation 'com.heroku.sdk:env-keystore:1.1.11'
 
-	implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:4.2.0'
-	implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:4.2.0'
-	implementation 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:4.2.0'
+	implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:8.0.0'
+	implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:8.0.0'
+	implementation 'ca.uhn.hapi.fhir:hapi-fhir-validation-resources-r4:8.0.0'
 	implementation 'com.google.guava:guava:29.0-jre'
 	implementation 'org.apache.qpid:qpid-jms-client:2.7.0'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.11.880'

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
@@ -1,8 +1,11 @@
 package uk.nhs.digital.nhsconnect.nhais.inbound;
 
 import org.assertj.core.api.SoftAssertions;
+import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
@@ -100,7 +103,7 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
     }
 
     @Test
-    void whenMeshInboundQueueRegistrationMessageIsReceived_thenMessageIsHandled(SoftAssertions softly) throws IOException, JMSException {
+    void whenMeshInboundQueueRegistrationMessageIsReceived_thenMessageIsHandled(SoftAssertions softly) throws IOException, JMSException, JSONException {
         var meshMessage = new MeshMessage()
             .setWorkflowId(WorkflowId.REGISTRATION)
             .setContent(new String(Files.readAllBytes(interchange.getFile().toPath())));
@@ -148,10 +151,10 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
         softly.assertThat(meshMessage.getMessageSentTimestamp()).isNull();
     }
 
-    private void assertGpSystemInboundQueueMessages(SoftAssertions softly) throws JMSException, IOException {
+    private void assertGpSystemInboundQueueMessages(SoftAssertions softly) throws JMSException, IOException, JSONException {
         var gpSystemInboundQueueMessages = IntStream.range(0, 6)
             .mapToObj(x -> getGpSystemInboundQueueMessage())
-            .collect(Collectors.toList());
+            .toList();
 
         assertGpSystemInboundQueueMessages(
             softly, gpSystemInboundQueueMessages.get(0), MESSAGE_1_TRANSACTION_TYPE, TRANSACTION_1_OPERATION_ID, fhirTN1);
@@ -172,7 +175,7 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
         Message message,
         ReferenceTransactionType.TransactionType expectedTransactionType,
         String expectedOperationId,
-        Resource expectedFhir) throws JMSException, IOException {
+        Resource expectedFhir) throws JMSException, IOException, JSONException {
 
         // all transactions come from the same interchange and use the same conversation id
         String conversationId = message.getStringProperty("ConversationId");
@@ -185,8 +188,12 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
             .isEqualTo(expectedOperationId);
         softly.assertThat(message.getStringProperty("TransactionType"))
             .isEqualTo(expectedTransactionType.name().toLowerCase());
-        softly.assertThat(parseTextMessage(message))
-            .isEqualTo(new String(Files.readAllBytes(expectedFhir.getFile().toPath())));
+
+        JSONAssert.assertEquals(
+            parseTextMessage(message),
+            new String(Files.readAllBytes(expectedFhir.getFile().toPath())),
+            JSONCompareMode.STRICT
+        );
     }
 
     private void assertInboundStates(SoftAssertions softly, List<InboundState> inboundStates) {

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueRegistrationTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueRegistrationTest.java
@@ -1,8 +1,11 @@
 package uk.nhs.digital.nhsconnect.nhais.inbound;
 
 import org.assertj.core.api.SoftAssertions;
+import org.json.JSONException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
@@ -63,7 +66,7 @@ public class InboundMeshQueueRegistrationTest extends IntegrationBaseTest {
     }
 
     @Test
-    void whenMeshInboundQueueRegistrationMessageIsReceived_thenMessageIsHandled(SoftAssertions softly) throws IOException, JMSException {
+    void whenMeshInboundQueueRegistrationMessageIsReceived_thenMessageIsHandled(SoftAssertions softly) throws IOException, JMSException, JSONException {
         var meshMessage = new MeshMessage()
             .setWorkflowId(WorkflowId.REGISTRATION)
             .setContent(new String(Files.readAllBytes(interchange.getFile().toPath())))
@@ -86,14 +89,15 @@ public class InboundMeshQueueRegistrationTest extends IntegrationBaseTest {
         softly.assertThat(meshMessage.getMessageSentTimestamp()).isNull();
     }
 
-    private void assertGpSystemInboundQueueMessage(SoftAssertions softly) throws JMSException, IOException {
+    private void assertGpSystemInboundQueueMessage(SoftAssertions softly) throws JMSException, IOException, JSONException {
         var message = getGpSystemInboundQueueMessage();
         var content = parseTextMessage(message);
         var expectedContent = new String(Files.readAllBytes(fhir.getFile().toPath()));
 
         softly.assertThat(message.getStringProperty("OperationId")).isEqualTo(OPERATION_ID);
         softly.assertThat(message.getStringProperty("TransactionType")).isEqualTo(TRANSACTION_TYPE.name().toLowerCase());
-        softly.assertThat(content).isEqualTo(expectedContent);
+
+        JSONAssert.assertEquals(expectedContent, content, JSONCompareMode.STRICT);
     }
 
     private void assertInboundState(SoftAssertions softly) {

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundUserAcceptanceTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundUserAcceptanceTest.java
@@ -1,10 +1,13 @@
 package uk.nhs.digital.nhsconnect.nhais.inbound;
 
+import org.json.JSONException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import uk.nhs.digital.nhsconnect.nhais.IntegrationBaseTest;
@@ -20,6 +23,7 @@ import uk.nhs.digital.nhsconnect.nhais.utils.JmsHeaders;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -99,7 +103,7 @@ public class InboundUserAcceptanceTest extends IntegrationBaseTest {
         assertThat(gpSystemInboundQueueMessage).isNull();
     }
 
-    private void verifyThatNonCloseQuarterNotificationMessageIsTranslated(TestData testData, Message gpSystemInboundQueueMessage) throws JMSException {
+    private void verifyThatNonCloseQuarterNotificationMessageIsTranslated(TestData testData, Message gpSystemInboundQueueMessage) throws JMSException, JSONException {
         assertThat(gpSystemInboundQueueMessage).isNotNull();
         // assert transaction type in JMS header is correct
         assertMessageHeaders(gpSystemInboundQueueMessage, "fp69_prior_notification");
@@ -107,9 +111,9 @@ public class InboundUserAcceptanceTest extends IntegrationBaseTest {
         assertMessageBody(gpSystemInboundQueueMessage, testData.getJson());
     }
 
-    private void assertMessageBody(Message gpSystemInboundQueueMessage, String expectedBody) throws JMSException {
+    private void assertMessageBody(Message gpSystemInboundQueueMessage, String expectedBody) throws JMSException, JSONException {
         var body = parseTextMessage(gpSystemInboundQueueMessage);
-        assertThat(body).isEqualTo(expectedBody);
+        JSONAssert.assertEquals(expectedBody, body, JSONCompareMode.STRICT);
     }
 
     private void assertMessageHeaders(Message gpSystemInboundQueueMessage, String expectedTransactionType) throws JMSException {

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/DeductionIntegrationTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/DeductionIntegrationTest.java
@@ -31,11 +31,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext
 public class DeductionIntegrationTest {
     public static final String URL = "/fhir/Patient/$nhais.deduction";
-    public static final String ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY =
+    private static final String ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY =
         "Invalid attribute value \"\": Attribute value must not be empty (\"\")";
-    public static final String INVALID_VALUE_STRING_PARAMETER =
+    private static final String INVALID_VALUE_STRING_PARAMETER =
         "Unable to parse JSON resource as a Parameters: HAPI-1821: [element=\"valueString\"] ";
-    public static final String INVALID_VALUE_PARAMETER =
+    private static final String INVALID_VALUE_PARAMETER =
         "Unable to parse JSON resource as a Parameters: HAPI-1821: [element=\"value\"] ";
 
     @Autowired

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/DeductionIntegrationTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/DeductionIntegrationTest.java
@@ -31,6 +31,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext
 public class DeductionIntegrationTest {
     public static final String URL = "/fhir/Patient/$nhais.deduction";
+    public static final String ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY =
+        "Invalid attribute value \"\": Attribute value must not be empty (\"\")";
+    public static final String INVALID_VALUE_STRING_PARAMETER =
+        "Unable to parse JSON resource as a Parameters: HAPI-1821: [element=\"valueString\"] ";
+    public static final String INVALID_VALUE_PARAMETER =
+        "Unable to parse JSON resource as a Parameters: HAPI-1821: [element=\"value\"] ";
 
     @Autowired
     private MockMvc mockMvc;
@@ -91,7 +97,8 @@ public class DeductionIntegrationTest {
             .andExpect(status().isBadRequest())
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
-        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText()).contains("Unable to parse JSON resource as a Parameters: Invalid attribute value \"\": Attribute values must not be empty (\"\")");
+        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
+            .contains(INVALID_VALUE_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -131,7 +138,8 @@ public class DeductionIntegrationTest {
             .andExpect(status().isBadRequest())
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
-        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText()).contains("Unable to parse JSON resource as a Parameters: Invalid attribute value \"\": Attribute values must not be empty (\"\")");
+        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
+            .contains(INVALID_VALUE_STRING_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -171,7 +179,8 @@ public class DeductionIntegrationTest {
             .andExpect(status().isBadRequest())
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
-        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText()).contains("Unable to parse JSON resource as a Parameters: Invalid attribute value \"\": Attribute values must not be empty (\"\")");
+        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
+            .contains(INVALID_VALUE_STRING_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
     @Test

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerIntegrationTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerIntegrationTest.java
@@ -25,6 +25,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Slf4j
 public class FhirControllerIntegrationTest {
+    private static final String INVALID_VALUE_STRING_PARAMETER =
+        "Unable to parse JSON resource as a Parameters: HAPI-1821: [element=\"valueString\"] ";
+    private static final String INVALID_VALUE_PARAMETER =
+        "Unable to parse JSON resource as a Parameters: HAPI-1821: [element=\"value\"] ";
+    private static final String ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY =
+        "Invalid attribute value \"\": Attribute value must not be empty (\"\")";
 
     @Autowired
     private MockMvc mockMvc;
@@ -80,7 +86,7 @@ public class FhirControllerIntegrationTest {
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
         assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
-            .contains("Invalid attribute value \"\": Attribute values must not be empty");
+            .contains(INVALID_VALUE_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -91,7 +97,7 @@ public class FhirControllerIntegrationTest {
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
         assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
-            .contains("Invalid attribute value \"\": Attribute values must not be empty");
+            .contains(INVALID_VALUE_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
 
@@ -103,7 +109,7 @@ public class FhirControllerIntegrationTest {
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
         assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
-            .contains("Invalid attribute value \"\": Attribute values must not be empty");
+            .contains(INVALID_VALUE_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -114,7 +120,7 @@ public class FhirControllerIntegrationTest {
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
         assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
-            .contains("Invalid attribute value \"\": Attribute values must not be empty");
+            .contains(INVALID_VALUE_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -125,7 +131,7 @@ public class FhirControllerIntegrationTest {
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
         assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
-            .contains("Invalid attribute value \"\": Attribute values must not be empty");
+            .contains(INVALID_VALUE_STRING_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
     @Test
@@ -136,7 +142,7 @@ public class FhirControllerIntegrationTest {
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
         assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
-            .contains("Invalid attribute value \"\": Attribute values must not be empty");
+            .contains(INVALID_VALUE_STRING_PARAMETER + ATTRIBUTE_VALUE_MUST_NOT_BE_EMPTY);
     }
 
     @Test

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/RemovalIntegrationTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/RemovalIntegrationTest.java
@@ -89,7 +89,11 @@ public class RemovalIntegrationTest {
             .andExpect(status().isBadRequest())
             .andReturn();
         OperationOutcome operationOutcome = (OperationOutcome) fhirParser.parse(result.getResponse().getContentAsString());
-        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText()).contains("Unable to parse JSON resource as a Parameters: Invalid attribute value \"\": Attribute values must not be empty (\"\")");
+        assertThat(operationOutcome.getIssueFirstRep().getDetails().getText())
+            .contains(
+                "Unable to parse JSON resource as a Parameters: HAPI-1821: [element=\"value\"] "
+                + "Invalid attribute value \"\": Attribute value must not be empty (\"\")"
+            );
     }
 
 

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/model/fhir/ParametersExtension.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/model/fhir/ParametersExtension.java
@@ -1,7 +1,6 @@
 package uk.nhs.digital.nhsconnect.nhais.model.fhir;
 
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Parameters;
@@ -14,7 +13,6 @@ import uk.nhs.digital.nhsconnect.nhais.model.edifact.AcceptanceType;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 @RequiredArgsConstructor
 public class ParametersExtension {
@@ -79,17 +77,13 @@ public class ParametersExtension {
     }
 
     public Optional<String> extractOptionalValue(String name) {
-        return Optional.ofNullable(parameters.getParameter(name))
+        return parameters.getParameter()
+            .stream()
+            .filter(p -> p.getName().equals(name))
+            .findFirst()
+            .map(Parameters.ParametersParameterComponent::getValue)
             .map(StringType.class::cast)
             .map(StringType::getValueAsString);
-    }
-
-    @SneakyThrows
-    public String extractValueOrThrow(String name, Supplier<? extends Throwable> exception) {
-        return Optional.ofNullable(parameters.getParameter(name))
-            .map(StringType.class::cast)
-            .map(StringType::getValueAsString)
-            .orElseThrow(exception);
     }
 
     public int size() {


### PR DESCRIPTION
* Update gradle resources to version `8.0.0`
* Breaking model changes now means that the `Parameter.getParameter(name)` now returns a `Type` which cannot now be cast to a `StringType`. We can work around this by finding the `ParametersParameterComponent` manually and then casting it to retrieve the value.
* Removed unused method `extractValueOrThrow`
* Due to Parameter changes in the latest version, there is now a slightly different error phrasing in the error returned when a parameter is missing or empty.  Integration tests have been updated to reflect this.