### PR TITLE
NAID-3322 - Review GitHub Actions NHS Best Practices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/publish.yml
     with:
-      directory: .
-      repository: nhais
-      build-context: .
       build-id: ${{ needs.generate-build-id.outputs.build-id }}
     secrets: inherit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
     uses: ./.github/workflows/test.yml
     permissions:
       contents: read
-      id-token: write
 
   generate-build-id:
     name: "Generate Build Id"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,16 +12,21 @@ jobs:
   tests:
     name: Tests
     uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
+      id-token: write
 
   generate-build-id:
     name: "Generate Build Id"
     needs: [ tests ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       build-id: ${{ steps.generate.outputs.buildId }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - id: generate
         working-directory: ./scripts
@@ -32,9 +37,9 @@ jobs:
           chmod +x ./create_build_id.sh
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          GIT_BRANCH=PR
+            GIT_BRANCH=PR
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-          GIT_BRANCH=main
+            GIT_BRANCH=main
           fi
 
           BUILD_ID=$(./create_build_id.sh $GIT_BRANCH ${{ github.run_number }} ${{ github.sha }})
@@ -44,7 +49,9 @@ jobs:
   publish-docker-image:
     name: "Publish docker image to ECR"
     needs: [ generate-build-id ]
-
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish.yml
     with:
       directory: .
@@ -63,10 +70,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |
             Images built and published to ECR using a Build Id of ${{ needs.generate-build-id.outputs.build-id }}
           comment-tag: images-built
           mode: upsert
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df #4.2.1 #4.2.1
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: gp2gp_github_action_build_workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,15 +2,6 @@ name: Publish Workflow
 on:
   workflow_call:
     inputs:
-      directory:
-        required: true
-        type: string
-      repository:
-        required: true
-        type: string
-      build-context:
-        required: true
-        type: string
       build-id:
         required: true
         type: string
@@ -28,7 +19,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df #4.2.1 #4.2.1
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df #4.2.1
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: gp2gp_github_action_build_workflow
@@ -37,11 +28,11 @@ jobs:
       - name: Build Docker Image
         run: |
           DOCKER_REGISTRY="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com"
-          DOCKER_TAG="$DOCKER_REGISTRY/${{ inputs.repository }}:${{ inputs.build-id }}"
+          DOCKER_TAG="$DOCKER_REGISTRY/nhais:${{ inputs.build-id }}"
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
 
           # Build Image
-          docker build -f ./${{ inputs.directory }}/Dockerfile -t $DOCKER_TAG ${{ inputs.build-context }}
+          docker build -f ./Dockerfile -t $DOCKER_TAG .
 
       - name: Login to AWS ECR
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,6 @@ jobs:
   integration_tests:
     name: Integration Tests
     permissions:
-      id-token: write
       contents: read
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
         with:
           java-version: 21
           distribution: temurin
@@ -26,7 +26,7 @@ jobs:
           cp -r ./build/reports ./artifacts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         if: always()
         with:
           name: Unit Test Report
@@ -35,7 +35,7 @@ jobs:
 
       - name: Test Job Summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 #v2.4.0
         with:
           paths: ./build/test-results/test/TEST-*.xml
 
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
         with:
           java-version: 21
           distribution: temurin
@@ -65,7 +65,7 @@ jobs:
           cp -r ./build/reports ./artifacts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         if: always()
         with:
           name: Component Test Report
@@ -74,7 +74,7 @@ jobs:
 
       - name: Test Job Summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 #v2.4.0
         with:
           paths: ./build/test-results/componentTest/TEST-*.xml
 
@@ -88,10 +88,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
         with:
           java-version: 21
           distribution: temurin
@@ -121,7 +121,7 @@ jobs:
           cp -r ./logs ./artifacts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         if: always()
         with:
           name: Integration Test Report & Docker Logs
@@ -130,7 +130,7 @@ jobs:
 
       - name: Test Job Summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 #v2.4.0
         with:
           paths: ./build/test-results/integrationTest/TEST-*.xml
 


### PR DESCRIPTION
* Restrict permissions per job to ensure that only the least required permissions are granted in `build` workflow.
* Use SHAs for GitHub Actions `actions` instead of versions to ensure we have control over exactly which version is being used in `build` workflow.
* Remove `id-token` write permissions from `integration_tests` job.
* Remove `id-token` write permissions from `build-and-publish-docker-image` job.