### PR TITLE
NIAD-3349: Perform `CheckStyle` fixes

### DIFF
--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/IntegrationAdaptorNhaisApplicationTests.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/IntegrationAdaptorNhaisApplicationTests.java
@@ -6,12 +6,10 @@ import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest
 @TestPropertySource(properties = {
-		"nhais.mongodb.autoIndexCreation=false" // no mongodb instance to create indexes at startup
+    "nhais.mongodb.autoIndexCreation=false" // no mongodb instance to create indexes at startup
 })
 class IntegrationAdaptorNhaisApplicationTests {
 
-	@Test
-	void When_DatabaseIsNotReachable_Expect_ApplicationStartsUpWithNegativeHealthcheck() {
-	}
-
+    @Test
+    void When_DatabaseIsNotReachable_Expect_ApplicationStartsUpWithNegativeHealthcheck() { }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdServiceTest.java
@@ -6,7 +6,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.nhs.digital.nhsconnect.nhais.model.edifact.*;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.Interchange;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.InterchangeHeader;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.Message;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.ReferenceTransactionNumber;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.ReferenceTransactionType;
+import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.utils.OperationId;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/RecepProducerServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/RecepProducerServiceTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -40,7 +41,7 @@ class RecepProducerServiceTest {
     private static final Long INTERCHANGE_SEQUENCE = 45L;
     private static final Long MESSAGE_SEQUENCE_1 = 56L;
     private static final Instant FIXED_TIME = ZonedDateTime
-        .of(2020, 4, 27, 17, 37, 0, 0, TimestampService.UK_ZONE)
+        .of(LocalDateTime.parse("2020-04-27T17:37:00"), TimestampService.UK_ZONE)
         .toInstant();
     private static final long RECEP_INTERCHANGE_SEQUENCE = 123123;
     private static final long RECEP_MESSAGE_SEQUENCE = 234234;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/EdifactToFhirServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/EdifactToFhirServiceTest.java
@@ -21,59 +21,61 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MockitoExtension.class)
 class EdifactToFhirServiceTest {
 
-    private final String rejectionMessage = "UNB+UNOA:2+TES5+XX11+020114:1619+00000003'\n" +
-        "UNH+00000004+FHSREG:0:1:FH:FHS001'\n" +
-        "BGM+++507'\n" +
-        "NAD+FHS+XX1:954'\n" +
-        "DTM+137:199201141619:203'\n" +
-        "RFF+950:F3'\n" +
-        "RFF+TN:18'\n" +
-        "S01+1'\n" +
-        "NAD+GP+2750922,295:900'\n" +
-        "NAD+RIC+RT:956'\n" +
-        "QTY+951:6'\n" +
-        "QTY+952:3'\n" +
-        "HEA+ACD+A:ZZZ'\n" +
-        "HEA+ATP+2:ZZZ'\n" +
-        "HEA+BM+S:ZZZ'\n" +
-        "HEA+DM+Y:ZZZ'\n" +
-        "DTM+956:19920114:102'\n" +
-        "LOC+950+GLASGOW'\n" +
-        "FTX+RGI+++BABY AT THE REYNOLDS-THORPE CENTRE'\n" +
-        "S02+2'\n" +
-        "PNA+PAT+NHS123:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA'\n" +
-        "DTM+329:19911209:102'\n" +
-        "PDI+2'\n" +
-        "NAD+PAT++??:26 FARMSIDE CLOSE:ST PAULS CRAY:ORPINGTON:KENT+++++BR6  7ET'\n" +
-        "UNT+24+00000004'\n" +
-        "UNZ+1+00000003'";
+    private final String rejectionMessage = """
+        UNB+UNOA:2+TES5+XX11+020114:1619+00000003'
+        UNH+00000004+FHSREG:0:1:FH:FHS001'
+        BGM+++507'
+        NAD+FHS+XX1:954'
+        DTM+137:199201141619:203'
+        RFF+950:F3'
+        RFF+TN:18'
+        S01+1'
+        NAD+GP+2750922,295:900'
+        NAD+RIC+RT:956'
+        QTY+951:6'
+        QTY+952:3'
+        HEA+ACD+A:ZZZ'
+        HEA+ATP+2:ZZZ'
+        HEA+BM+S:ZZZ'
+        HEA+DM+Y:ZZZ'
+        DTM+956:19920114:102'
+        LOC+950+GLASGOW'
+        FTX+RGI+++BABY AT THE REYNOLDS-THORPE CENTRE'
+        S02+2'
+        PNA+PAT+NHS123:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA'
+        DTM+329:19911209:102'
+        PDI+2'
+        NAD+PAT++??:26 FARMSIDE CLOSE:ST PAULS CRAY:ORPINGTON:KENT+++++BR6  7ET'
+        UNT+24+00000004'
+        UNZ+1+00000003'""";
 
-    private final String approvalMessage = "UNB+UNOA:2+TES5+XX11+020114:1619+00000003'\n" +
-        "UNH+00000004+FHSREG:0:1:FH:FHS001'\n" +
-        "BGM+++507'\n" +
-        "NAD+FHS+XX1:954'\n" +
-        "DTM+137:199201141619:203'\n" +
-        "RFF+950:F4'\n" +
-        "RFF+TN:18'\n" +
-        "S01+1'\n" +
-        "NAD+GP+2750922,295:900'\n" +
-        "NAD+RIC+RT:956'\n" +
-        "QTY+951:6'\n" +
-        "QTY+952:3'\n" +
-        "HEA+ACD+A:ZZZ'\n" +
-        "HEA+ATP+2:ZZZ'\n" +
-        "HEA+BM+S:ZZZ'\n" +
-        "HEA+DM+Y:ZZZ'\n" +
-        "DTM+956:19920114:102'\n" +
-        "LOC+950+GLASGOW'\n" +
-        "FTX+RGI+++BABY AT THE REYNOLDS-THORPE CENTRE'\n" +
-        "S02+2'\n" +
-        "PNA+PAT+NHS123:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA'\n" +
-        "DTM+329:19911209:102'\n" +
-        "PDI+2'\n" +
-        "NAD+PAT++??:26 FARMSIDE CLOSE:ST PAULS CRAY:ORPINGTON:KENT+++++BR6  7ET'\n" +
-        "UNT+24+00000004'\n" +
-        "UNZ+1+00000003'";
+    private final String approvalMessage = """
+        UNB+UNOA:2+TES5+XX11+020114:1619+00000003'
+        UNH+00000004+FHSREG:0:1:FH:FHS001'
+        BGM+++507'
+        NAD+FHS+XX1:954'
+        DTM+137:199201141619:203'
+        RFF+950:F4'
+        RFF+TN:18'
+        S01+1'
+        NAD+GP+2750922,295:900'
+        NAD+RIC+RT:956'
+        QTY+951:6'
+        QTY+952:3'
+        HEA+ACD+A:ZZZ'
+        HEA+ATP+2:ZZZ'
+        HEA+BM+S:ZZZ'
+        HEA+DM+Y:ZZZ'
+        DTM+956:19920114:102'
+        LOC+950+GLASGOW'
+        FTX+RGI+++BABY AT THE REYNOLDS-THORPE CENTRE'
+        S02+2'
+        PNA+PAT+NHS123:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA'
+        DTM+329:19911209:102'
+        PDI+2'
+        NAD+PAT++??:26 FARMSIDE CLOSE:ST PAULS CRAY:ORPINGTON:KENT+++++BR6  7ET'
+        UNT+24+00000004'
+        UNZ+1+00000003'""";
 
     private Map<ReferenceTransactionType.TransactionType, FhirTransactionMapper> transactionMappers;
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/DeductionRejectionTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/DeductionRejectionTransactionMapperTest.java
@@ -56,6 +56,8 @@ class DeductionRejectionTransactionMapperTest {
 
     @Test
     void When_AllDataPresent_Expect_Mapped(SoftAssertions softly) {
+        final int expectedParametersCount = 3;
+
         when(transaction.getPersonName()).thenReturn(Optional.of(personName));
         when(personName.getNhsNumber()).thenReturn(NHS_NUMBER);
         when(transaction.getFreeText()).thenReturn(Optional.of(new FreeText("TEXT VALUE")));
@@ -70,7 +72,7 @@ class DeductionRejectionTransactionMapperTest {
 
         ParametersExtension parametersExt = new ParametersExtension(parameters);
 
-        softly.assertThat(parametersExt.size()).isEqualTo(3);
+        softly.assertThat(parametersExt.size()).isEqualTo(expectedParametersCount);
         Patient patient = parametersExt.extractPatient();
         softly.assertThat(patient.getIdentifierFirstRep().getValue()).isEqualTo(NHS_NUMBER);
         softly.assertThat(patient.getIdentifierFirstRep().getSystem()).isEqualTo(NhsIdentifier.SYSTEM);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/DeductionTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/DeductionTransactionMapperTest.java
@@ -62,6 +62,7 @@ class DeductionTransactionMapperTest {
 
     @Test
     void When_AllFieldsInTransaction_Expect_MapAllFields(SoftAssertions softly) {
+        final int expectedParametersCount = 5;
         when(transaction.getPersonName()).thenReturn(Optional.of(personName));
         when(transaction.getDeductionReasonCode()).thenReturn(Optional.of(deductionReasonCode));
         when(transaction.getDeductionDate()).thenReturn(Optional.of(deductionDate));
@@ -81,7 +82,7 @@ class DeductionTransactionMapperTest {
 
         ParametersExtension parametersExt = new ParametersExtension(parameters);
 
-        softly.assertThat(parametersExt.size()).isEqualTo(5);
+        softly.assertThat(parametersExt.size()).isEqualTo(expectedParametersCount);
         Patient patient = parametersExt.extractPatient();
         softly.assertThat(patient.getIdentifierFirstRep().getValue()).isEqualTo(NHS_NUMBER);
         softly.assertThat(patient.getIdentifierFirstRep().getSystem()).isEqualTo(NhsIdentifier.SYSTEM);
@@ -92,6 +93,8 @@ class DeductionTransactionMapperTest {
 
     @Test
     void When_AllMandatoryFieldsInTransaction_Expect_MapOnlyMandatoryFields(SoftAssertions softly) {
+        final int expectedParametersCount = 4;
+
         when(transaction.getPersonName()).thenReturn(Optional.of(personName));
         when(transaction.getDeductionReasonCode()).thenReturn(Optional.of(deductionReasonCode));
         when(transaction.getDeductionDate()).thenReturn(Optional.of(deductionDate));
@@ -110,7 +113,7 @@ class DeductionTransactionMapperTest {
 
         ParametersExtension parametersExt = new ParametersExtension(parameters);
 
-        softly.assertThat(parametersExt.size()).isEqualTo(4);
+        softly.assertThat(parametersExt.size()).isEqualTo(expectedParametersCount);
         Patient patient = parametersExt.extractPatient();
         softly.assertThat(patient.getIdentifierFirstRep().getValue()).isEqualTo(NHS_NUMBER);
         softly.assertThat(patient.getIdentifierFirstRep().getSystem()).isEqualTo(NhsIdentifier.SYSTEM);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/FP69FlagRemovalTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/FP69FlagRemovalTransactionMapperTest.java
@@ -3,8 +3,6 @@ package uk.nhs.digital.nhsconnect.nhais.inbound.fhir.mapper;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.hl7.fhir.r4.model.Patient;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/FP69PriorNotificationTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/FP69PriorNotificationTransactionMapperTest.java
@@ -47,6 +47,12 @@ class FP69PriorNotificationTransactionMapperTest {
     private static final String ADDRESS_LINE_4 = "1/4";
     private static final String ADDRESS_LINE_5 = null;
     private static final String POSTAL_CODE = "ABC-123";
+    private static final int ADDRESS_LINE_1_INDEX = 0;
+    private static final int ADDRESS_LINE_2_INDEX = 1;
+    private static final int ADDRESS_LINE_3_INDEX = 2;
+    private static final int ADDRESS_LINE_4_INDEX = 3;
+    private static final int ADDRESS_LINE_5_INDEX = 4;
+
     @InjectMocks
     private FP69PriorNotificationTransactionMapper transactionMapper;
 
@@ -190,6 +196,8 @@ class FP69PriorNotificationTransactionMapperTest {
 
     @Test
     void When_MappingAllValues_Expect_ParametersAreMapped(SoftAssertions softly) {
+        final int expectedAddressLineCount = 5;
+
         when(transaction.getMessage()).thenReturn(message);
         when(transaction.getGpNameAndAddress()).thenReturn(gpNameAndAddress);
         when(message.getInterchange()).thenReturn(interchange);
@@ -224,17 +232,18 @@ class FP69PriorNotificationTransactionMapperTest {
 
         softly.assertThat(patient.getAddress()).hasSize(1);
         var address = patient.getAddressFirstRep();
-        softly.assertThat(address.getLine()).hasSize(5);
-        softly.assertThat(address.getLine().get(0).getValue()).isEqualTo(ADDRESS_LINE_1);
-        softly.assertThat(address.getLine().get(1).getValue()).isEqualTo(ADDRESS_LINE_2);
-        softly.assertThat(address.getLine().get(2).getValue()).isEqualTo(ADDRESS_LINE_3);
-        softly.assertThat(address.getLine().get(3).getValue()).isEqualTo(ADDRESS_LINE_4);
-        softly.assertThat(address.getLine().get(4).getValue()).isEqualTo(ADDRESS_LINE_5);
+        softly.assertThat(address.getLine()).hasSize(expectedAddressLineCount);
+        softly.assertThat(address.getLine().get(ADDRESS_LINE_1_INDEX).getValue()).isEqualTo(ADDRESS_LINE_1);
+        softly.assertThat(address.getLine().get(ADDRESS_LINE_2_INDEX).getValue()).isEqualTo(ADDRESS_LINE_2);
+        softly.assertThat(address.getLine().get(ADDRESS_LINE_3_INDEX).getValue()).isEqualTo(ADDRESS_LINE_3);
+        softly.assertThat(address.getLine().get(ADDRESS_LINE_4_INDEX).getValue()).isEqualTo(ADDRESS_LINE_4);
+        softly.assertThat(address.getLine().get(ADDRESS_LINE_5_INDEX).getValue()).isEqualTo(ADDRESS_LINE_5);
         softly.assertThat(address.getPostalCode()).isEqualTo(POSTAL_CODE);
     }
 
     private void assertRequiredFields(SoftAssertions softly, Parameters parameters) {
-        softly.assertThat(parameters.getParameter()).hasSize(4);
+        final int expectedParameterCount = 4;
+        softly.assertThat(parameters.getParameter()).hasSize(expectedParameterCount);
 
         var patient = ParametersExtension.extractPatient(parameters);
         softly.assertThat(patient.getName()).hasSize(1);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/FP69PriorNotificationTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/FP69PriorNotificationTransactionMapperTest.java
@@ -133,7 +133,9 @@ class FP69PriorNotificationTransactionMapperTest {
 
         assertThatThrownBy(() -> transactionMapper.map(transaction))
             .isInstanceOf(EdifactValidationException.class)
-            .hasMessage("For an FP69 prior notification (reference F9) the DTM+329 segment is required to provide the patient date of birth");
+            .hasMessage(
+                "For an FP69 prior notification (reference F9) the DTM+329 segment is required to provide the patient date of birth"
+            );
     }
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/RejectionTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/fhir/mapper/RejectionTransactionMapperTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 class RejectionTransactionMapperTest {
 
     private static final String TEXT_LITERAL = "some_text_literal";
+    private static final int EXPECTED_PARAMETER_COUNT = 3;
     @Mock
     private Transaction transaction;
     @Mock
@@ -58,7 +59,7 @@ class RejectionTransactionMapperTest {
 
         ParametersExtension parametersExt = new ParametersExtension(parameters);
 
-        softly.assertThat(parameters.getParameter().size()).isEqualTo(3);
+        softly.assertThat(parameters.getParameter().size()).isEqualTo(EXPECTED_PARAMETER_COUNT);
         softly.assertThat(parametersExt.extractValue(ParameterNames.FREE_TEXT)).isEqualTo(TEXT_LITERAL);
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressCountyPatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressCountyPatchTransactionMapperTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.AddressCountyPatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonAddress;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressHouseNamePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressHouseNamePatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.AddressHouseNamePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonAddress;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressLocalityPatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressLocalityPatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.AddressLocalityPatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonAddress;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressNumberOrRoadNamePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressNumberOrRoadNamePatchTransactionMapperTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.AddressNumberOrRoadNamePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonAddress;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressPostCodePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressPostCodePatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.AddressPostCodePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonAddress;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressPostTownPatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AddressPostTownPatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.AddressPostTownPatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonAddress;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AmendedNhsNumberPatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/AmendedNhsNumberPatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.AmendedNhsNumberPatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonPreviousName;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/FirstForenamePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/FirstForenamePatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.FirstForenamePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonName;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/PreviousSurnamePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/PreviousSurnamePatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.PreviousSurnamePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonPreviousName;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/SecondForenamePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/SecondForenamePatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.SecondForenamePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonName;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/SurnamePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/SurnamePatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.SurnamePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonName;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/ThirdForenamePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/ThirdForenamePatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.ThirdForenamePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonName;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/TitlePatchTransactionMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/jsonpatch/mapper/TitlePatchTransactionMapperTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import uk.nhs.digital.nhsconnect.nhais.inbound.jsonpatch.mapper.TitlePatchTransactionMapper;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.PersonName;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.Transaction;
 import uk.nhs.digital.nhsconnect.nhais.model.jsonpatch.AmendmentPatch;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueServiceTest.java
@@ -125,7 +125,7 @@ public class InboundQueueServiceTest {
     }
 
     @Test
-    public void When_ReceiveUnknownWorkflow_Expect_ThrowsUnknownWorkflowExceptionWithNoAck() throws Exception{
+    public void When_ReceiveUnknownWorkflow_Expect_ThrowsUnknownWorkflowExceptionWithNoAck() throws Exception {
         when(message.getBody(String.class)).thenReturn("{}");
         when(message.getStringProperty(JmsHeaders.CONVERSATION_ID)).thenReturn(CONVERSATION_ID);
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueServiceTest.java
@@ -1,7 +1,6 @@
 package uk.nhs.digital.nhsconnect.nhais.inbound.queue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -29,8 +28,6 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundQueueServiceTest.java
@@ -149,7 +149,12 @@ public class InboundQueueServiceTest {
         inboundQueueService.publish(inboundMeshMessage);
 
         // the method parameter is modified so another copy is needed. Timestamp set to expected value
-        InboundMeshMessage expectedInboundMeshMessage = InboundMeshMessage.create(WorkflowId.REGISTRATION, "ASDF", messageSentTimestamp, "ID123");
+        InboundMeshMessage expectedInboundMeshMessage = InboundMeshMessage.create(
+            WorkflowId.REGISTRATION,
+            "ASDF",
+            messageSentTimestamp,
+            "ID123"
+        );
         String expectedStringMessage = objectMapper.writeValueAsString(expectedInboundMeshMessage);
         verify(jmsTemplate).send(org.mockito.Mockito.<String>isNull(), jmsMessageCreatorCaptor.capture());
         MessageCreator messageCreator = jmsMessageCreatorCaptor.getValue();

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactoryTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactoryTest.java
@@ -35,7 +35,8 @@ public class InboundStateFactoryTest {
     private static final String OPERATION_ID = "4b93239acaf902960fad67a339cfda2c1c0f771d51122627066cfcc667bc6b16";
     private static final String SENDER = "some_sender";
     private static final String RECIPIENT = "some_recipient";
-    private static final Instant TRANSLATION_TIMESTAMP = ZonedDateTime.now().minusHours(4).toInstant();
+    private static final Integer FOUR_HOURS = 4;
+    private static final Instant TRANSLATION_TIMESTAMP = ZonedDateTime.now().minusHours(FOUR_HOURS).toInstant();
     private static final Instant PROCESSED_TIMESTAMP = Instant.now();
     private static final long INTERCHANGE_SEQUENCE = 123L;
     private static final long MESSAGE_SEQUENCE = 234L;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactoryTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactoryTest.java
@@ -68,16 +68,16 @@ public class InboundStateFactoryTest {
         .setConversationId(CONVERSATION_ID);
 
     @Mock
-    TimestampService timestampService;
+    private TimestampService timestampService;
 
     @Mock
-    ConversationIdService conversationIdService;
+    private ConversationIdService conversationIdService;
 
     @Mock
-    InboundOperationIdService inboundOperationIdService;
+    private InboundOperationIdService inboundOperationIdService;
 
     @InjectMocks
-    InboundStateFactory inboundStateFactory;
+    private InboundStateFactory inboundStateFactory;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactoryTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/state/InboundStateFactoryTest.java
@@ -81,7 +81,10 @@ public class InboundStateFactoryTest {
 
     @BeforeEach
     void setUp() {
-        when(INTERCHANGE.getInterchangeHeader()).thenReturn(new InterchangeHeader(SENDER, RECIPIENT, TRANSLATION_TIMESTAMP).setSequenceNumber(INTERCHANGE_SEQUENCE));
+        when(INTERCHANGE.getInterchangeHeader())
+            .thenReturn(
+                new InterchangeHeader(SENDER, RECIPIENT, TRANSLATION_TIMESTAMP).setSequenceNumber(INTERCHANGE_SEQUENCE)
+            );
         when(INTERCHANGE.getMessages()).thenReturn(List.of(MESSAGE));
 
         when(MESSAGE.getMessageHeader()).thenReturn(new MessageHeader().setSequenceNumber(MESSAGE_SEQUENCE));
@@ -89,7 +92,10 @@ public class InboundStateFactoryTest {
         when(MESSAGE.getInterchange()).thenReturn(INTERCHANGE);
         when(MESSAGE.getTransactions()).thenReturn(List.of(TRANSACTION));
 
-        when(TRANSACTION.getReferenceTransactionNumber()).thenReturn(new ReferenceTransactionNumber().setTransactionNumber(TRANSACTION_NUMBER));
+        when(TRANSACTION.getReferenceTransactionNumber())
+            .thenReturn(
+                new ReferenceTransactionNumber().setTransactionNumber(TRANSACTION_NUMBER)
+            );
         when(TRANSACTION.getMessage()).thenReturn(MESSAGE);
 
         when(timestampService.getCurrentTimestamp()).thenReturn(PROCESSED_TIMESTAMP);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/MeshMailBoxSchedulerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/MeshMailBoxSchedulerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class MeshMailBoxSchedulerTest {
 
+    private static final int FIVE_SECONDS = 5;
     @InjectMocks
     private MeshMailBoxScheduler meshMailBoxScheduler;
 
@@ -39,7 +40,7 @@ public class MeshMailBoxSchedulerTest {
         when(schedulerTimestampRepository.updateTimestamp(anyString(), isA(Instant.class), anyLong())).thenReturn(false);
         when(timestampService.getCurrentTimestamp()).thenReturn(Instant.now());
 
-        boolean hasTimePassed = meshMailBoxScheduler.hasTimePassed(5);
+        boolean hasTimePassed = meshMailBoxScheduler.hasTimePassed(FIVE_SECONDS);
 
         assertThat(hasTimePassed).isFalse();
     }
@@ -49,7 +50,7 @@ public class MeshMailBoxSchedulerTest {
         when(schedulerTimestampRepository.updateTimestamp(anyString(), isA(Instant.class), anyLong())).thenReturn(true);
         when(timestampService.getCurrentTimestamp()).thenReturn(Instant.now());
 
-        boolean hasTimePassed = meshMailBoxScheduler.hasTimePassed(5);
+        boolean hasTimePassed = meshMailBoxScheduler.hasTimePassed(FIVE_SECONDS);
 
         assertThat(hasTimePassed).isTrue();
     }
@@ -59,7 +60,7 @@ public class MeshMailBoxSchedulerTest {
         when(schedulerTimestampRepository.updateTimestamp(anyString(), isA(Instant.class), anyLong())).thenReturn(false);
         when(timestampService.getCurrentTimestamp()).thenReturn(Instant.now());
 
-        boolean hasTimePassed = meshMailBoxScheduler.hasTimePassed(5);
+        boolean hasTimePassed = meshMailBoxScheduler.hasTimePassed(FIVE_SECONDS);
 
         assertThat(hasTimePassed).isFalse();
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/MeshMailBoxSchedulerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/MeshMailBoxSchedulerTest.java
@@ -13,7 +13,9 @@ import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/MeshServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/MeshServiceTest.java
@@ -241,7 +241,8 @@ class MeshServiceTest {
     public void When_IntervalHasPassedButAuthenticationFails_Expect_StopProcessing() {
         when(meshMailBoxScheduler.hasTimePassed(scanDelayInSeconds)).thenReturn(true);
         when(meshMailBoxScheduler.isEnabled()).thenReturn(true);
-        doThrow(new MeshApiConnectionException("Auth fail", HttpStatus.OK, HttpStatus.INTERNAL_SERVER_ERROR)).when(meshClient).authenticate();
+        doThrow(new MeshApiConnectionException("Auth fail", HttpStatus.OK, HttpStatus.INTERNAL_SERVER_ERROR))
+            .when(meshClient).authenticate();
 
         Assertions.assertThatThrownBy(() -> meshService.scanMeshInboxForMessages())
             .isExactlyInstanceOf(MeshApiConnectionException.class);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/MeshServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/MeshServiceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MeshServiceTest {
 
+    private static final long ONE_SECOND = 1000L;
     @Mock
     private MeshClient meshClient;
 
@@ -95,7 +96,7 @@ class MeshServiceTest {
         when(meshMailBoxScheduler.isEnabled()).thenReturn(true);
         when(meshClient.getInboxMessageIds()).thenReturn(List.of(MESSAGE_ID1, MESSAGE_ID2));
         when(meshClient.getEdifactMessage(any())).thenAnswer((invocation) -> {
-            Thread.sleep((pollingCycleMaximumDurationInSeconds + 1) * 1000L); // ensure first download exceeds duration
+            Thread.sleep((pollingCycleMaximumDurationInSeconds + 1) * ONE_SECOND); // ensure first download exceeds duration
             return meshMessage1;
         });
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/scheduler/SchedulerTimestampRepositoryExtensionTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/scheduler/SchedulerTimestampRepositoryExtensionTest.java
@@ -28,6 +28,7 @@ import static uk.nhs.digital.nhsconnect.nhais.mesh.scheduler.SchedulerTimestampR
 public class SchedulerTimestampRepositoryExtensionTest {
 
     private static final String SCHEDULER_TYPE = "meshTimestamp";
+    private static final int THREE_HUNDRED_SECONDS = 300;
 
     @InjectMocks
     private SchedulerTimestampRepositoryExtensionsImpl schedulerTimestampRepositoryExtensions;
@@ -47,7 +48,7 @@ public class SchedulerTimestampRepositoryExtensionTest {
         Instant timestamp = Instant.now();
         when(timestampService.getCurrentTimestamp()).thenReturn(timestamp);
 
-        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, timestamp, 300);
+        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, timestamp, THREE_HUNDRED_SECONDS);
 
         assertThat(updated).isFalse();
         var expected = new SchedulerTimestamp(SCHEDULER_TYPE, timestamp);
@@ -61,7 +62,7 @@ public class SchedulerTimestampRepositoryExtensionTest {
         MongoWriteException exception = mock(MongoWriteException.class);
         when(mongoOperations.save(any(), eq(MESH_TIMESTAMP_COLLECTION_NAME))).thenThrow(exception);
 
-        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, Instant.now(), 300);
+        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, Instant.now(), THREE_HUNDRED_SECONDS);
 
         assertThat(updated).isFalse();
     }
@@ -73,7 +74,7 @@ public class SchedulerTimestampRepositoryExtensionTest {
         DuplicateKeyException exception = mock(DuplicateKeyException.class);
         when(mongoOperations.save(any(), eq(MESH_TIMESTAMP_COLLECTION_NAME))).thenThrow(exception);
 
-        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, Instant.now(), 300);
+        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, Instant.now(), THREE_HUNDRED_SECONDS);
 
         assertThat(updated).isFalse();
     }
@@ -86,7 +87,7 @@ public class SchedulerTimestampRepositoryExtensionTest {
         when(updateResult.getModifiedCount()).thenReturn(1L);
         when(timestampService.getCurrentTimestamp()).thenReturn(Instant.now());
 
-        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, Instant.now(), 300);
+        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, Instant.now(), THREE_HUNDRED_SECONDS);
 
         assertThat(updated).isTrue();
     }
@@ -99,7 +100,7 @@ public class SchedulerTimestampRepositoryExtensionTest {
         when(updateResult.getModifiedCount()).thenReturn(0L);
         when(timestampService.getCurrentTimestamp()).thenReturn(Instant.now());
 
-        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, Instant.now(), 300);
+        boolean updated = schedulerTimestampRepositoryExtensions.updateTimestamp(SCHEDULER_TYPE, Instant.now(), THREE_HUNDRED_SECONDS);
 
         assertThat(updated).isFalse();
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/AuthorizationHashGeneratorTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/AuthorizationHashGeneratorTest.java
@@ -20,13 +20,13 @@ class AuthorizationHashGeneratorTest {
     @Mock
     private MeshConfig meshConfig;
 
-    private final static String MAILBOX_ID = "mailbox_id";
-    private final static String MAILBOX_PASSWORD = "mailbox_password";
-    private final static String SHARED_KEY = "shared_key";
+    private static final String MAILBOX_ID = "mailbox_id";
+    private static final String MAILBOX_PASSWORD = "mailbox_password";
+    private static final String SHARED_KEY = "shared_key";
 
-    private final static Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
+    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
         .toInstant();
-    private final static String UUID = "73eefd69-811f-44d0-81f8-a54ff352a991";
+    private static final String UUID = "73eefd69-811f-44d0-81f8-a54ff352a991";
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/AuthorizationHashGeneratorTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/AuthorizationHashGeneratorTest.java
@@ -9,6 +9,7 @@ import uk.nhs.digital.nhsconnect.nhais.mesh.http.MeshConfig;
 import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +25,8 @@ class AuthorizationHashGeneratorTest {
     private static final String MAILBOX_PASSWORD = "mailbox_password";
     private static final String SHARED_KEY = "shared_key";
 
-    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
+    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime
+        .of(LocalDateTime.parse("1991-11-06T12:30:00"), TimestampService.UK_ZONE)
         .toInstant();
     private static final String UUID = "73eefd69-811f-44d0-81f8-a54ff352a991";
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/MeshAuthorizationTokenTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/MeshAuthorizationTokenTest.java
@@ -46,7 +46,13 @@ class MeshAuthorizationTokenTest {
 
     @Test
     void testTokenUsesCorrectFormat() {
-        MeshAuthorizationToken meshToken = new MeshAuthorizationToken(meshConfig, FIXED_TIME_LOCAL, new Nonce(UUID), authorizationHashGenerator);
+        MeshAuthorizationToken meshToken = new MeshAuthorizationToken(
+            meshConfig,
+            FIXED_TIME_LOCAL,
+            new Nonce(UUID),
+            authorizationHashGenerator
+        );
+
         SoftAssertions.assertSoftly(softly -> {
             String[] values = meshToken.getValue().split(":");
             softly.assertThat(values[EDIFACT_MAILBOX_INDEX])
@@ -60,7 +66,10 @@ class MeshAuthorizationTokenTest {
             softly.assertThat(values[EDIFACT_AUTHORIZATION_HASH_INDEX])
                 .isEqualTo(AUTHORIZATION_HASH);
             softly.assertThat(meshToken.getValue())
-                .isEqualTo("NHSMESH mailbox_id:73eefd69-811f-44d0-81f8-a54ff352a991:1:199111061230:474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569");
+                .isEqualTo(
+                    "NHSMESH mailbox_id:73eefd69-811f-44d0-81f8-a54ff352a991:1"
+                        + ":199111061230:474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569"
+                );
         });
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/MeshAuthorizationTokenTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/MeshAuthorizationTokenTest.java
@@ -19,12 +19,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MeshAuthorizationTokenTest {
 
-    private final static String AUTHORIZATION_HASH = "474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569";
-    private final static String MAILBOX_ID = "mailbox_id";
+    private static final String AUTHORIZATION_HASH = "474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569";
+    private static final String MAILBOX_ID = "mailbox_id";
 
-    private final static Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
+    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
         .toInstant();
-    private final static String UUID = "73eefd69-811f-44d0-81f8-a54ff352a991";
+    private static final String UUID = "73eefd69-811f-44d0-81f8-a54ff352a991";
 
     @Mock
     private MeshConfig meshConfig;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/MeshAuthorizationTokenTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/MeshAuthorizationTokenTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import uk.nhs.digital.nhsconnect.nhais.mesh.http.MeshConfig;
@@ -22,7 +23,8 @@ class MeshAuthorizationTokenTest {
     private static final String AUTHORIZATION_HASH = "474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569";
     private static final String MAILBOX_ID = "mailbox_id";
 
-    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
+    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime
+        .of(LocalDateTime.parse("1991-11-06T12:30:00"), TimestampService.UK_ZONE)
         .toInstant();
     private static final String UUID = "73eefd69-811f-44d0-81f8-a54ff352a991";
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/MeshAuthorizationTokenTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/MeshAuthorizationTokenTest.java
@@ -22,6 +22,11 @@ class MeshAuthorizationTokenTest {
 
     private static final String AUTHORIZATION_HASH = "474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569";
     private static final String MAILBOX_ID = "mailbox_id";
+    private static final int EDIFACT_MAILBOX_INDEX = 0;
+    private static final int EDIFACT_NONCE_VALUE_INDEX = 1;
+    private static final int EDIFACT_NONCE_COUNT_INDEX = 2;
+    private static final int EDIFACT_TIMESTAMP_INDEX = 3;
+    private static final int EDIFACT_AUTHORIZATION_HASH_INDEX = 4;
 
     private static final Instant FIXED_TIME_LOCAL = ZonedDateTime
         .of(LocalDateTime.parse("1991-11-06T12:30:00"), TimestampService.UK_ZONE)
@@ -44,11 +49,16 @@ class MeshAuthorizationTokenTest {
         MeshAuthorizationToken meshToken = new MeshAuthorizationToken(meshConfig, FIXED_TIME_LOCAL, new Nonce(UUID), authorizationHashGenerator);
         SoftAssertions.assertSoftly(softly -> {
             String[] values = meshToken.getValue().split(":");
-            softly.assertThat(values[0]).isEqualTo("NHSMESH " + MAILBOX_ID);
-            softly.assertThat(values[1]).isEqualTo(UUID);
-            softly.assertThat(values[2]).isEqualTo("1");
-            softly.assertThat(values[3]).isEqualTo(new TokenTimestamp(FIXED_TIME_LOCAL).getValue());
-            softly.assertThat(values[4]).isEqualTo(AUTHORIZATION_HASH);
+            softly.assertThat(values[EDIFACT_MAILBOX_INDEX])
+                .isEqualTo("NHSMESH " + MAILBOX_ID);
+            softly.assertThat(values[EDIFACT_NONCE_VALUE_INDEX])
+                .isEqualTo(UUID);
+            softly.assertThat(values[EDIFACT_NONCE_COUNT_INDEX])
+                .isEqualTo("1");
+            softly.assertThat(values[EDIFACT_TIMESTAMP_INDEX])
+                .isEqualTo(new TokenTimestamp(FIXED_TIME_LOCAL).getValue());
+            softly.assertThat(values[EDIFACT_AUTHORIZATION_HASH_INDEX])
+                .isEqualTo(AUTHORIZATION_HASH);
             softly.assertThat(meshToken.getValue())
                 .isEqualTo("NHSMESH mailbox_id:73eefd69-811f-44d0-81f8-a54ff352a991:1:199111061230:474c0634fd2267e41252bddfb40031d85e433599a8015c74546e95b05c2df569");
         });

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/TokenTimestampTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/TokenTimestampTest.java
@@ -3,6 +3,7 @@ package uk.nhs.digital.nhsconnect.nhais.mesh.token;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
@@ -11,7 +12,8 @@ import org.junit.jupiter.api.Test;
 
 class TokenTimestampTest {
 
-    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
+    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime
+        .of(LocalDateTime.parse("1991-11-06T12:30:00"), TimestampService.UK_ZONE)
         .toInstant();
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/TokenTimestampTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/mesh/token/TokenTimestampTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 
 class TokenTimestampTest {
 
-    private final static Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
+    private static final Instant FIXED_TIME_LOCAL = ZonedDateTime.of(1991,11,6,12,30,0,0, TimestampService.UK_ZONE)
         .toInstant();
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/AcceptanceDateTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/AcceptanceDateTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class AcceptanceDateTest {
 
-    private final LocalDate DATE = LocalDate.of(2020, 3, 28);
+    private static final LocalDate DATE = LocalDate.of(2020, 3, 28);
 
     @Test
     public void When_ToEdifactAndInstantInWinter_Expect_EdifactIsCorrect() throws EdifactValidationException {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/AcceptanceTypeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/AcceptanceTypeTest.java
@@ -1,7 +1,6 @@
 package uk.nhs.digital.nhsconnect.nhais.model.edifact;
 
 import org.junit.jupiter.api.Test;
-import uk.nhs.digital.nhsconnect.nhais.model.edifact.message.EdifactValidationException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/DeductionDateTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/DeductionDateTest.java
@@ -18,7 +18,7 @@ public class DeductionDateTest {
     @Test
     void When_FromStringWithValidInput_Expect_SegmentCreated() {
         DeductionDate deductionDate = DeductionDate.fromString("DTM+961:20050115:102");
-        DeductionDate expectedDeductionDate = new DeductionDate(LocalDate.of(2005,1,15));
+        DeductionDate expectedDeductionDate = new DeductionDate(LocalDate.parse("2005-01-15"));
 
         assertThat(deductionDate.getValue()).isEqualTo(expectedDeductionDate.getValue());
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/FP69ExpiryDateTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/FP69ExpiryDateTest.java
@@ -17,7 +17,7 @@ class FP69ExpiryDateTest {
 
     @Test
     void toEdifact() {
-        var fp69ReasonCode = new FP69ExpiryDate(LocalDate.of(1990, 1, 23));
+        var fp69ReasonCode = new FP69ExpiryDate(LocalDate.parse("1990-01-23"));
 
         assertThat(fp69ReasonCode.toEdifact())
             .isEqualTo("DTM+962:19900123:102'");
@@ -26,6 +26,6 @@ class FP69ExpiryDateTest {
     @Test
     void fromEdifact() {
         assertThat(FP69ExpiryDate.fromString("DTM+962:19920225:102"))
-            .isEqualTo(new FP69ExpiryDate(LocalDate.of(1992, 2, 25)));
+            .isEqualTo(new FP69ExpiryDate(LocalDate.parse("1992-02-25")));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/FP69ReasonCodeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/FP69ReasonCodeTest.java
@@ -24,7 +24,7 @@ class FP69ReasonCodeTest {
 
     @Test
     void fromEdifact() {
-        assertThat(FP69ReasonCode.fromString("HEA+FRN+" + REASON_CODE+ ":ZZZ"))
+        assertThat(FP69ReasonCode.fromString("HEA+FRN+" + REASON_CODE + ":ZZZ"))
             .isEqualTo(new FP69ReasonCode(REASON_CODE));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/FP69ReasonCodeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/FP69ReasonCodeTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class FP69ReasonCodeTest {
+    private static final int REASON_CODE = 123;
 
     @Test
     void When_SettingNullCode_Expect_Exception() {
@@ -15,15 +16,15 @@ class FP69ReasonCodeTest {
 
     @Test
     void toEdifact() {
-        var fp69ReasonCode = new FP69ReasonCode(123);
+        var fp69ReasonCode = new FP69ReasonCode(REASON_CODE);
 
         assertThat(fp69ReasonCode.toEdifact())
-            .isEqualTo("HEA+FRN+123:ZZZ'");
+            .isEqualTo("HEA+FRN+" + REASON_CODE + ":ZZZ'");
     }
 
     @Test
     void fromEdifact() {
-        assertThat(FP69ReasonCode.fromString("HEA+FRN+8:ZZZ"))
-            .isEqualTo(new FP69ReasonCode(8));
+        assertThat(FP69ReasonCode.fromString("HEA+FRN+" + REASON_CODE+ ":ZZZ"))
+            .isEqualTo(new FP69ReasonCode(REASON_CODE));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/GpNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/GpNameAndAddressTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GpNameAndAddressTest {
 
-    public final GpNameAndAddress gpNameAndAddress = new GpNameAndAddress("ABC", "code1");
+    private final GpNameAndAddress gpNameAndAddress = new GpNameAndAddress("ABC", "code1");
 
     @Test
     void testGetKey() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/HealthAuthorityNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/HealthAuthorityNameAndAddressTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HealthAuthorityNameAndAddressTest {
 
-    public final HealthAuthorityNameAndAddress healthAuthorityNameAndAddress = new HealthAuthorityNameAndAddress("ABC", "code1");
+    private final HealthAuthorityNameAndAddress healthAuthorityNameAndAddress = new HealthAuthorityNameAndAddress("ABC", "code1");
 
     @Test
     void testGetKey() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/HealthAuthorityNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/HealthAuthorityNameAndAddressTest.java
@@ -44,8 +44,10 @@ class HealthAuthorityNameAndAddressTest {
 
     @Test
     void testFromString() {
-        assertThat(HealthAuthorityNameAndAddress.fromString("NAD+FHS+ABC:code1").getValue()).isEqualTo(healthAuthorityNameAndAddress.getValue());
-        assertThatThrownBy(() -> HealthAuthorityNameAndAddress.fromString("wrong value")).isExactlyInstanceOf(IllegalArgumentException.class);
+        assertThat(HealthAuthorityNameAndAddress.fromString("NAD+FHS+ABC:code1").getValue())
+            .isEqualTo(healthAuthorityNameAndAddress.getValue());
+        assertThatThrownBy(() -> HealthAuthorityNameAndAddress.fromString("wrong value"))
+            .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/HealthAuthorityNameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/HealthAuthorityNameAndAddressTest.java
@@ -31,7 +31,7 @@ class HealthAuthorityNameAndAddressTest {
     void testPreValidate() {
         HealthAuthorityNameAndAddress emptyIdentifier = new HealthAuthorityNameAndAddress("", "x");
         HealthAuthorityNameAndAddress emptyCode = new HealthAuthorityNameAndAddress("x", "");
-        SoftAssertions.assertSoftly( softly -> {
+        SoftAssertions.assertSoftly(softly -> {
             softly.assertThatThrownBy(emptyIdentifier::preValidate)
                 .isExactlyInstanceOf(EdifactValidationException.class)
                 .hasMessage("NAD: Attribute identifier is required");

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeHeaderTest.java
@@ -22,8 +22,10 @@ public class InterchangeHeaderTest {
         .toInstant();
     private static final long SEQUENCE_NUMBER_OUT_OF_UPPER_BOUND = 100_000_000L;
     private static final long MAX_SEQUENCE_NUMBER = 99_999_999L;
-    private final InterchangeHeader interchangeHeaderWinter = new InterchangeHeader("SNDR", "RECP", TRANSLATION_WINTER_DATE_TIME).setSequenceNumber(1L);
-    private final InterchangeHeader interchangeHeaderSummer = new InterchangeHeader("SNDR", "RECP", TRANSLATION_SUMMER_DATE_TIME).setSequenceNumber(1L);
+    private final InterchangeHeader interchangeHeaderWinter =
+        new InterchangeHeader("SNDR", "RECP", TRANSLATION_WINTER_DATE_TIME).setSequenceNumber(1L);
+    private final InterchangeHeader interchangeHeaderSummer =
+        new InterchangeHeader("SNDR", "RECP", TRANSLATION_SUMMER_DATE_TIME).setSequenceNumber(1L);
 
     @Test
     public void testValidInterchangeHeaderWithWinterTime() throws EdifactValidationException {
@@ -86,7 +88,9 @@ public class InterchangeHeaderTest {
 
     @Test
     void testFromString() {
-        assertThat(InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190323:0900+00000001").getValue()).isEqualTo(interchangeHeaderWinter.getValue());
-        assertThatThrownBy(() -> InterchangeHeader.fromString("wrong value")).isExactlyInstanceOf(IllegalArgumentException.class);
+        assertThat(InterchangeHeader.fromString("UNB+UNOA:2+SNDR+RECP+190323:0900+00000001").getValue())
+            .isEqualTo(interchangeHeaderWinter.getValue());
+        assertThatThrownBy(() -> InterchangeHeader.fromString("wrong value"))
+            .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeHeaderTest.java
@@ -20,6 +20,8 @@ public class InterchangeHeaderTest {
     private static final Instant TRANSLATION_SUMMER_DATE_TIME = ZonedDateTime
         .of(LocalDateTime.parse("2019-05-23T09:00:00"), ZoneOffset.UTC)
         .toInstant();
+    private static final long SEQUENCE_NUMBER_OUT_OF_UPPER_BOUND = 100_000_000L;
+    private static final long MAX_SEQUENCE_NUMBER = 99_999_999L;
     private final InterchangeHeader interchangeHeaderWinter = new InterchangeHeader("SNDR", "RECP", TRANSLATION_WINTER_DATE_TIME).setSequenceNumber(1L);
     private final InterchangeHeader interchangeHeaderSummer = new InterchangeHeader("SNDR", "RECP", TRANSLATION_SUMMER_DATE_TIME).setSequenceNumber(1L);
 
@@ -54,7 +56,7 @@ public class InterchangeHeaderTest {
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("UNB: Attribute sequenceNumber must be between 1 and 99999999");
 
-        interchangeHeader.setSequenceNumber(100_000_000L);
+        interchangeHeader.setSequenceNumber(SEQUENCE_NUMBER_OUT_OF_UPPER_BOUND);
         assertThatThrownBy(interchangeHeader::validateStateful)
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("UNB: Attribute sequenceNumber must be between 1 and 99999999");
@@ -62,7 +64,7 @@ public class InterchangeHeaderTest {
         interchangeHeader.setSequenceNumber(1L);
         interchangeHeader.validateStateful();
 
-        interchangeHeader.setSequenceNumber(99_999_999L);
+        interchangeHeader.setSequenceNumber(MAX_SEQUENCE_NUMBER);
         interchangeHeader.validateStateful();
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeHeaderTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.message.EdifactValidationException;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
@@ -14,10 +15,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class InterchangeHeaderTest {
 
     private static final Instant TRANSLATION_WINTER_DATE_TIME = ZonedDateTime
-        .of(2019, 3, 23, 9, 0, 0, 0, ZoneOffset.UTC)
+        .of(LocalDateTime.parse("2019-03-23T09:00:00"), ZoneOffset.UTC)
         .toInstant();
     private static final Instant TRANSLATION_SUMMER_DATE_TIME = ZonedDateTime
-        .of(2019, 5, 23, 9, 0, 0, 0, ZoneOffset.UTC)
+        .of(LocalDateTime.parse("2019-05-23T09:00:00"), ZoneOffset.UTC)
         .toInstant();
     private final InterchangeHeader interchangeHeaderWinter = new InterchangeHeader("SNDR", "RECP", TRANSLATION_WINTER_DATE_TIME).setSequenceNumber(1L);
     private final InterchangeHeader interchangeHeaderSummer = new InterchangeHeader("SNDR", "RECP", TRANSLATION_SUMMER_DATE_TIME).setSequenceNumber(1L);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeHeaderTest.java
@@ -13,10 +13,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class InterchangeHeaderTest {
 
-    private final Instant TRANSLATION_WINTER_DATE_TIME = ZonedDateTime
+    private static final Instant TRANSLATION_WINTER_DATE_TIME = ZonedDateTime
         .of(2019, 3, 23, 9, 0, 0, 0, ZoneOffset.UTC)
         .toInstant();
-    private final Instant TRANSLATION_SUMMER_DATE_TIME = ZonedDateTime
+    private static final Instant TRANSLATION_SUMMER_DATE_TIME = ZonedDateTime
         .of(2019, 5, 23, 9, 0, 0, 0, ZoneOffset.UTC)
         .toInstant();
     private final InterchangeHeader interchangeHeaderWinter = new InterchangeHeader("SNDR", "RECP", TRANSLATION_WINTER_DATE_TIME).setSequenceNumber(1L);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeTrailerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/InterchangeTrailerTest.java
@@ -47,7 +47,10 @@ public class InterchangeTrailerTest {
 
     @Test
     void testFromString() {
-        var expectedInterchangeTrailer = new InterchangeTrailer(18).setSequenceNumber(3L);
+        final int numberOfMessages = 18;
+        final long sequenceNumber = 3L;
+        var expectedInterchangeTrailer = new InterchangeTrailer(numberOfMessages)
+            .setSequenceNumber(sequenceNumber);
         var edifact = "UNZ+18+00000003'";
 
         var interchangeTrailer = InterchangeTrailer.fromString(edifact);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/MessageHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/MessageHeaderTest.java
@@ -8,11 +8,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MessageHeaderTest {
+    private static final long SEQUENCE_NUMBER_OUT_OF_UPPER_BOUND = 100_000_000L;
+    private static final long MAX_SEQUENCE_NUMBER = 99_999_999L;
 
     @Test
     public void testValidMessageHeader() throws EdifactValidationException {
+        final long sequenceNumber = 3L;
         MessageHeader messageHeader = new MessageHeader();
-        messageHeader.setSequenceNumber(3L);
+        messageHeader.setSequenceNumber(sequenceNumber);
 
         String edifact = messageHeader.toEdifact();
 
@@ -30,6 +33,7 @@ public class MessageHeaderTest {
 
     @Test
     public void testValidationStatefulMinMaxSequenceNumber() throws EdifactValidationException {
+        final long sequenceNumber = 1L;
         var messageHeader = new MessageHeader();
 
         messageHeader.setSequenceNumber(0L);
@@ -37,22 +41,23 @@ public class MessageHeaderTest {
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("UNH: Attribute sequenceNumber must be between 1 and 99999999");
 
-        messageHeader.setSequenceNumber(100_000_000L);
+        messageHeader.setSequenceNumber(SEQUENCE_NUMBER_OUT_OF_UPPER_BOUND);
         assertThatThrownBy(messageHeader::validateStateful)
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("UNH: Attribute sequenceNumber must be between 1 and 99999999");
 
-        messageHeader.setSequenceNumber(1L);
+        messageHeader.setSequenceNumber(sequenceNumber);
         messageHeader.validateStateful();
 
-        messageHeader.setSequenceNumber(99_999_999L);
+        messageHeader.setSequenceNumber(MAX_SEQUENCE_NUMBER);
         messageHeader.validateStateful();
     }
 
     @Test
     void testFromString() {
+        final long sequenceNumber = 3L;
         MessageHeader messageHeader = new MessageHeader();
-        messageHeader.setSequenceNumber(3L);
+        messageHeader.setSequenceNumber(sequenceNumber);
 
         assertThat(MessageHeader.fromString("UNH+00000003+FHSREG:0:1:FH:FHS001").getValue()).isEqualTo(messageHeader.getValue());
         assertThatThrownBy(() -> MessageHeader.fromString("wrong value")).isExactlyInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/MessageTrailerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/MessageTrailerTest.java
@@ -10,10 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MessageTrailerTest {
 
+    private static final int NUMBER_OF_SEGMENTS = 18;
+    private static final long SEQUENCE_NUMBER = 3L;
+
     @Test
     public void testValidMessageHeader() throws EdifactValidationException {
-        MessageTrailer messageTrailer = new MessageTrailer(18);
-        messageTrailer.setSequenceNumber(3L);
+        MessageTrailer messageTrailer = new MessageTrailer(NUMBER_OF_SEGMENTS);
+        messageTrailer.setSequenceNumber(SEQUENCE_NUMBER);
 
         String edifact = messageTrailer.toEdifact();
 
@@ -22,7 +25,7 @@ public class MessageTrailerTest {
 
     @Test
     public void testValidationStatefulNonSequenceNumber() {
-        MessageTrailer messageTrailer = new MessageTrailer(18);
+        MessageTrailer messageTrailer = new MessageTrailer(NUMBER_OF_SEGMENTS);
 
         Exception exception = assertThrows(EdifactValidationException.class, messageTrailer::validateStateful);
 
@@ -35,7 +38,7 @@ public class MessageTrailerTest {
     @Test
     public void testValidationStatefulInvalidNumberOfSegments() {
         MessageTrailer messageTrailer = new MessageTrailer(-1);
-        messageTrailer.setSequenceNumber(3L);
+        messageTrailer.setSequenceNumber(SEQUENCE_NUMBER);
 
         Exception exception = assertThrows(EdifactValidationException.class, messageTrailer::validateStateful);
 
@@ -47,7 +50,7 @@ public class MessageTrailerTest {
 
     @Test
     void testFromString() {
-        var expectedMessageTrailer = new MessageTrailer(18).setSequenceNumber(3L);
+        var expectedMessageTrailer = new MessageTrailer(NUMBER_OF_SEGMENTS).setSequenceNumber(SEQUENCE_NUMBER);
         var edifact = "UNT+18+00000003'";
 
         var messageTrailer = MessageTrailer.fromString(edifact);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/NameAndAddressTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/NameAndAddressTest.java
@@ -12,7 +12,7 @@ public class NameAndAddressTest {
 
     @Test
     public void testValidMessageHeader() throws EdifactValidationException {
-        NameAndAddress nameAndAddress = new NameAndAddress("PARTY",NameAndAddress.QualifierAndCode.FHS);
+        NameAndAddress nameAndAddress = new NameAndAddress("PARTY", NameAndAddress.QualifierAndCode.FHS);
 
         String edifact = nameAndAddress.toEdifact();
 
@@ -21,7 +21,7 @@ public class NameAndAddressTest {
 
     @Test
     public void testValidationStatefulNonSequenceNumber() {
-        NameAndAddress nameAndAddress = new NameAndAddress("",NameAndAddress.QualifierAndCode.FHS);
+        NameAndAddress nameAndAddress = new NameAndAddress("", NameAndAddress.QualifierAndCode.FHS);
 
         Exception exception = assertThrows(EdifactValidationException.class, nameAndAddress::preValidate);
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/NewHealthAuthorityNameTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/NewHealthAuthorityNameTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NewHealthAuthorityNameTest {
 
-    private final static String IDENTIFIER = "ID1";
+    private static final String IDENTIFIER = "ID1";
 
     @Test
     void toEdifact() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/PersonNameTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/PersonNameTest.java
@@ -8,13 +8,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PersonNameTest {
-    private final static String NHS_AND_NAMES = "PNA+PAT+RAT56:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
-    private final static String NHS_AND_NAMES_VALUE = "PAT+RAT56:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
-    private final static String NAMES_ONLY = "PNA+PAT++++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
-    private final static String NAMES_ONLY_VALUE = "PAT++++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
-    private final static String NHS_ONLY = "PNA+PAT+RAT56:OPI";
-    private final static String NHS_ONLY_VALUE = "PAT+RAT56:OPI";
-    private final static String BLANK_NHS_VALUE = "PNA+PAT+   +++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NHS_AND_NAMES = "PNA+PAT+RAT56:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NHS_AND_NAMES_VALUE = "PAT+RAT56:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NAMES_ONLY = "PNA+PAT++++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NAMES_ONLY_VALUE = "PAT++++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NHS_ONLY = "PNA+PAT+RAT56:OPI";
+    private static final String NHS_ONLY_VALUE = "PAT+RAT56:OPI";
+    private static final String BLANK_NHS_VALUE = "PNA+PAT+   +++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
 
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/PersonPreviousNameTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/PersonPreviousNameTest.java
@@ -9,12 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class PersonPreviousNameTest {
 
-    private final static String NHS_AND_NAMES = "PNA+PER+RAT56:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
-    private final static String NHS_AND_NAMES_VALUE = "PER+RAT56:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
-    private final static String NAMES_ONLY = "PNA+PER++++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
-    private final static String NAMES_ONLY_VALUE = "PER++++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
-    private final static String NHS_ONLY = "PNA+PER+RAT56:OPI";
-    private final static String NHS_ONLY_VALUE = "PER+RAT56:OPI";
+    private static final String NHS_AND_NAMES = "PNA+PER+RAT56:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NHS_AND_NAMES_VALUE = "PER+RAT56:OPI+++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NAMES_ONLY = "PNA+PER++++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NAMES_ONLY_VALUE = "PER++++SU:KENNEDY+FO:SARAH+TI:MISS+MI:ANGELA";
+    private static final String NHS_ONLY = "PNA+PER+RAT56:OPI";
+    private static final String NHS_ONLY_VALUE = "PER+RAT56:OPI";
 
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/PreviousHealthAuthorityNameTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/PreviousHealthAuthorityNameTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 class PreviousHealthAuthorityNameTest {
 
-    private final static String IDENTIFIER = "ID1";
+    private static final String IDENTIFIER = "ID1";
 
     @Test
     void toEdifact() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepHeaderTest.java
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RecepHeaderTest {
-    private final Instant DATE_TIME = ZonedDateTime
+    private static final Instant DATE_TIME = ZonedDateTime
         .of(2019, 3, 23, 9, 0, 0, 0, ZoneOffset.UTC)
         .toInstant();
     private final RecepHeader recepHeader = new RecepHeader("SNDR", "RECP", DATE_TIME).setSequenceNumber(1L);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepHeaderTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepHeaderTest.java
@@ -3,6 +3,7 @@ package uk.nhs.digital.nhsconnect.nhais.model.edifact;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
@@ -10,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class RecepHeaderTest {
     private static final Instant DATE_TIME = ZonedDateTime
-        .of(2019, 3, 23, 9, 0, 0, 0, ZoneOffset.UTC)
+        .of(LocalDateTime.parse("2019-03-23T09:00:00"), ZoneOffset.UTC)
         .toInstant();
     private final RecepHeader recepHeader = new RecepHeader("SNDR", "RECP", DATE_TIME).setSequenceNumber(1L);
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepMessageDateTimeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepMessageDateTimeTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.message.EdifactValidationException;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
@@ -13,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class RecepMessageDateTimeTest {
 
     private static final Instant WINTER = ZonedDateTime
-        .of(2020, 3, 28, 20, 58, 0, 0, ZoneOffset.UTC)
+        .of(LocalDateTime.parse("2020-03-28T20:58:00"), ZoneOffset.UTC)
         .toInstant();
     private static final Instant SUMMER = ZonedDateTime
-        .of(2020, 5, 28, 20, 58, 0, 0, ZoneOffset.UTC)
+        .of(LocalDateTime.parse("2020-05-28T20:58:00"), ZoneOffset.UTC)
         .toInstant();
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepMessageDateTimeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepMessageDateTimeTest.java
@@ -12,10 +12,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class RecepMessageDateTimeTest {
 
-    private final Instant WINTER = ZonedDateTime
+    private static final Instant WINTER = ZonedDateTime
         .of(2020, 3, 28, 20, 58, 0, 0, ZoneOffset.UTC)
         .toInstant();
-    private final Instant SUMMER = ZonedDateTime
+    private static final Instant SUMMER = ZonedDateTime
         .of(2020, 5, 28, 20, 58, 0, 0, ZoneOffset.UTC)
         .toInstant();
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepMessageTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepMessageTest.java
@@ -17,18 +17,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SoftAssertionsExtension.class)
 class RecepMessageTest {
 
-    private final String exampleMessage = "UNB+UNOA:2+FHS1+GP05+020114:1619+00000064++RECEP+++EDIFACT TRANSFER'\n" +
-        "UNH+00000028+RECEP:0:2:FH'\n" +
-        "BGM++600+243:199305201355:306+64'\n" +
-        "NHS+FHS:819:201+123456:814:202'\n" +
-        "DTM+815:199305190600:306'\n" +
-        "RFF+MIS:00000101 CP'\n" +
-        "RFF+MIS:00000102 CA'\n" +
-        "RFF+MIS:00000103 CI'\n" +
-        "RFF+MIS:00000104 CP'\n" +
-        "RFF+RIS:00000100 OK:4'\n" +
-        "UNT+10+00000028'\n" +
-        "UNZ+1+00000064'";
+    private final String exampleMessage = """
+        UNB+UNOA:2+FHS1+GP05+020114:1619+00000064++RECEP+++EDIFACT TRANSFER'
+        UNH+00000028+RECEP:0:2:FH'
+        BGM++600+243:199305201355:306+64'
+        NHS+FHS:819:201+123456:814:202'
+        DTM+815:199305190600:306'
+        RFF+MIS:00000101 CP'
+        RFF+MIS:00000102 CA'
+        RFF+MIS:00000103 CI'
+        RFF+MIS:00000104 CP'
+        RFF+RIS:00000100 OK:4'
+        UNT+10+00000028'
+        UNZ+1+00000064'""";
 
     @Test
     void testParsingInterchangeHeader() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepMessageTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RecepMessageTest.java
@@ -17,6 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SoftAssertionsExtension.class)
 class RecepMessageTest {
 
+    private static final long FIRST_SUCCESS_KEY = 101L;
+    private static final long ERROR_KEY = 102L;
+    private static final long INCOMPLETE_KEY = 103L;
+    private static final long SECOND_SUCCESS_KEY = 104L;
     private final String exampleMessage = """
         UNB+UNOA:2+FHS1+GP05+020114:1619+00000064++RECEP+++EDIFACT TRANSFER'
         UNH+00000028+RECEP:0:2:FH'
@@ -33,6 +37,7 @@ class RecepMessageTest {
 
     @Test
     void testParsingInterchangeHeader() {
+        final long expectedSequenceNumber = 64L;
         var recepMessage = new RecepMessage(exampleMessage);
         InterchangeHeader interchangeHeader = recepMessage.getInterchangeHeader();
 
@@ -42,32 +47,35 @@ class RecepMessageTest {
             .parse("020114:1619", DateTimeFormatter.ofPattern("yyMMdd:HHmm").withZone(ZoneId.of("Europe/London")))
             .toInstant();
         assertThat(interchangeHeader.getTranslationTime()).isEqualTo(expectedTime);
-        assertThat(interchangeHeader.getSequenceNumber()).isEqualTo(64L);
+        assertThat(interchangeHeader.getSequenceNumber()).isEqualTo(expectedSequenceNumber);
     }
 
     @Test
     void testParsingReferenceInterchangeRecep() {
+        final long expectedInterchangeSequenceNumber = 100L;
+        final int expectedMessageCount = 4;
         var recepMessage = new RecepMessage(exampleMessage);
         var referenceInterchangeRecep = recepMessage.getReferenceInterchangeRecep();
 
-        assertThat(referenceInterchangeRecep.getInterchangeSequenceNumber()).isEqualTo(100L);
+        assertThat(referenceInterchangeRecep.getInterchangeSequenceNumber()).isEqualTo(expectedInterchangeSequenceNumber);
         assertThat(referenceInterchangeRecep.getRecepCode()).isEqualTo(ReferenceInterchangeRecep.RecepCode.RECEIVED);
-        assertThat(referenceInterchangeRecep.getMessageCount()).isEqualTo(4);
+        assertThat(referenceInterchangeRecep.getMessageCount()).isEqualTo(expectedMessageCount);
     }
 
     @Test
     void testParsingReferenceMessageRecep(SoftAssertions softly) {
+        final int expectedReferenceMessageCount = 4;
         var recepMessage = new RecepMessage(exampleMessage);
         var referenceMessageReceps = recepMessage.getReferenceMessageReceps();
 
         var expectedReceps = List.of(
-            Pair.of(101L, ReferenceMessageRecep.RecepCode.SUCCESS),
-            Pair.of(102L, ReferenceMessageRecep.RecepCode.ERROR),
-            Pair.of(103L, ReferenceMessageRecep.RecepCode.INCOMPLETE),
-            Pair.of(104L, ReferenceMessageRecep.RecepCode.SUCCESS)
+            Pair.of(FIRST_SUCCESS_KEY, ReferenceMessageRecep.RecepCode.SUCCESS),
+            Pair.of(ERROR_KEY, ReferenceMessageRecep.RecepCode.ERROR),
+            Pair.of(INCOMPLETE_KEY, ReferenceMessageRecep.RecepCode.INCOMPLETE),
+            Pair.of(SECOND_SUCCESS_KEY, ReferenceMessageRecep.RecepCode.SUCCESS)
         );
 
-        softly.assertThat(referenceMessageReceps.size()).isEqualTo(4);
+        softly.assertThat(referenceMessageReceps.size()).isEqualTo(expectedReferenceMessageCount);
 
         for (int i = 0; i < referenceMessageReceps.size(); i++) {
             softly

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceInterchangeRecepTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceInterchangeRecepTest.java
@@ -10,10 +10,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SoftAssertionsExtension.class)
 class ReferenceInterchangeRecepTest {
+
+    private static final long INTERCHANGE_SEQUENCE_NUMBER = 123L;
+    private static final int MESSAGE_COUNT = 3;
+
     @Test
     void When_GettingKey_Expect_ReturnsProperValue() {
         String key = new ReferenceInterchangeRecep(
-            123L, ReferenceInterchangeRecep.RecepCode.RECEIVED, 3)
+            INTERCHANGE_SEQUENCE_NUMBER, ReferenceInterchangeRecep.RecepCode.RECEIVED, MESSAGE_COUNT)
             .getKey();
 
         assertThat(key).isEqualTo("RFF");
@@ -22,7 +26,7 @@ class ReferenceInterchangeRecepTest {
     @Test
     void When_GettingValue_Expect_ReturnsProperValue() {
         String value = new ReferenceInterchangeRecep(
-            123L, ReferenceInterchangeRecep.RecepCode.RECEIVED, 3)
+            INTERCHANGE_SEQUENCE_NUMBER, ReferenceInterchangeRecep.RecepCode.RECEIVED, MESSAGE_COUNT)
             .getValue();
 
         assertThat("RIS:00000123 OK:3").isEqualTo(value);
@@ -31,19 +35,19 @@ class ReferenceInterchangeRecepTest {
     @Test
     void When_PreValidatedDataViolatesNullChecks_Expect_ThrowsException(SoftAssertions softly) {
         softly.assertThatThrownBy(
-            () -> new ReferenceInterchangeRecep(null, ReferenceInterchangeRecep.RecepCode.RECEIVED, 3)
+            () -> new ReferenceInterchangeRecep(null, ReferenceInterchangeRecep.RecepCode.RECEIVED, MESSAGE_COUNT)
                 .preValidate())
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("RFF: Attribute messageSequenceNumber is required");
 
         softly.assertThatThrownBy(
-            () -> new ReferenceInterchangeRecep(123L, null, 3)
+            () -> new ReferenceInterchangeRecep(INTERCHANGE_SEQUENCE_NUMBER, null, MESSAGE_COUNT)
                 .preValidate())
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("RFF: Attribute recepCode is required");
 
         softly.assertThatThrownBy(
-            () -> new ReferenceInterchangeRecep(123L, ReferenceInterchangeRecep.RecepCode.RECEIVED, null)
+            () -> new ReferenceInterchangeRecep(INTERCHANGE_SEQUENCE_NUMBER, ReferenceInterchangeRecep.RecepCode.RECEIVED, null)
                 .preValidate())
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("RFF: Attribute messageCount is required");
@@ -51,23 +55,39 @@ class ReferenceInterchangeRecepTest {
 
     @Test
     void When_Parsing_Expect_RecepCreated() {
+        final long expectedReceivedInterchangeSequenceNumber = 5L;
+        final long expectedInvalidDataInterchangeSequenceNumber = 10000006L;
+        final long expectedNoValidDataInterchangeSequenceNumber = 99000006L;
+        final int expectedReceivedMessageCount = 4;
+        final int expectedInvalidDataMessageCount = 5;
+        final int expectedNoValidDataMessageCount = 10;
+
         var recepRow = ReferenceInterchangeRecep.fromString("RFF+RIS:00000005 OK:4");
 
-        assertThat(recepRow.getInterchangeSequenceNumber()).isEqualTo(5L);
-        assertThat(recepRow.getRecepCode()).isEqualTo(ReferenceInterchangeRecep.RecepCode.RECEIVED);
-        assertThat(recepRow.getMessageCount()).isEqualTo(4);
+        assertThat(recepRow.getInterchangeSequenceNumber())
+            .isEqualTo(expectedReceivedInterchangeSequenceNumber);
+        assertThat(recepRow.getRecepCode())
+            .isEqualTo(ReferenceInterchangeRecep.RecepCode.RECEIVED);
+        assertThat(recepRow.getMessageCount())
+            .isEqualTo(expectedReceivedMessageCount);
 
         recepRow = ReferenceInterchangeRecep.fromString("RFF+RIS:10000006 ER:5:QWE+ASD");
 
-        assertThat(recepRow.getInterchangeSequenceNumber()).isEqualTo(10000006L);
-        assertThat(recepRow.getRecepCode()).isEqualTo(ReferenceInterchangeRecep.RecepCode.INVALID_DATA);
-        assertThat(recepRow.getMessageCount()).isEqualTo(5);
+        assertThat(recepRow.getInterchangeSequenceNumber())
+            .isEqualTo(expectedInvalidDataInterchangeSequenceNumber);
+        assertThat(recepRow.getRecepCode())
+            .isEqualTo(ReferenceInterchangeRecep.RecepCode.INVALID_DATA);
+        assertThat(recepRow.getMessageCount())
+            .isEqualTo(expectedInvalidDataMessageCount);
 
         recepRow = ReferenceInterchangeRecep.fromString("RFF+RIS:99000006 NA:10:QWE:ASD++");
 
-        assertThat(recepRow.getInterchangeSequenceNumber()).isEqualTo(99000006L);
-        assertThat(recepRow.getRecepCode()).isEqualTo(ReferenceInterchangeRecep.RecepCode.NO_VALID_DATA);
-        assertThat(recepRow.getMessageCount()).isEqualTo(10);
+        assertThat(recepRow.getInterchangeSequenceNumber())
+            .isEqualTo(expectedNoValidDataInterchangeSequenceNumber);
+        assertThat(recepRow.getRecepCode())
+            .isEqualTo(ReferenceInterchangeRecep.RecepCode.NO_VALID_DATA);
+        assertThat(recepRow.getMessageCount())
+            .isEqualTo(expectedNoValidDataMessageCount);
     }
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceMessageRecepTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceMessageRecepTest.java
@@ -11,10 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SoftAssertionsExtension.class)
 class ReferenceMessageRecepTest {
 
+    private static final long MESSAGE_SEQUENCE_NUMBER = 123L;
+
     @Test
     void When_GettingKey_Expect_ReturnsProperValue() {
         String key = new ReferenceMessageRecep(
-            123L, ReferenceMessageRecep.RecepCode.ERROR)
+            MESSAGE_SEQUENCE_NUMBER, ReferenceMessageRecep.RecepCode.ERROR)
             .getKey();
 
         assertThat(key).isEqualTo("RFF");
@@ -23,7 +25,7 @@ class ReferenceMessageRecepTest {
     @Test
     void When_GettingValue_Expect_ReturnsProperValue() {
         String value = new ReferenceMessageRecep(
-            123L, ReferenceMessageRecep.RecepCode.ERROR)
+            MESSAGE_SEQUENCE_NUMBER, ReferenceMessageRecep.RecepCode.ERROR)
             .getValue();
 
         assertThat("MIS:00000123 CA").isEqualTo(value);
@@ -38,7 +40,7 @@ class ReferenceMessageRecepTest {
             .hasMessage("RFF: Attribute messageSequenceNumber is required");
 
         softly.assertThatThrownBy(
-            () -> new ReferenceMessageRecep(123L, null)
+            () -> new ReferenceMessageRecep(MESSAGE_SEQUENCE_NUMBER, null)
                 .preValidate())
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("RFF: Attribute recepCode is required");
@@ -46,19 +48,23 @@ class ReferenceMessageRecepTest {
 
     @Test
     void When_Parsing_Expect_RecepCreated(SoftAssertions softly) {
+        final long expectedSuccessMessageSequenceNumber = 5L;
+        final long expectedErrorMessageSequenceNumber = 10000006L;
+        final long expectedIncompleteMessageSequenceNumber = 99000006L;
+
         var recepRow = ReferenceMessageRecep.fromString("RFF+MIS:00000005 CP");
 
-        softly.assertThat(recepRow.getMessageSequenceNumber()).isEqualTo(5L);
+        softly.assertThat(recepRow.getMessageSequenceNumber()).isEqualTo(expectedSuccessMessageSequenceNumber);
         softly.assertThat(recepRow.getRecepCode()).isEqualTo(ReferenceMessageRecep.RecepCode.SUCCESS);
 
         recepRow = ReferenceMessageRecep.fromString("RFF+MIS:10000006 CA:5:QWE+ASD");
 
-        softly.assertThat(recepRow.getMessageSequenceNumber()).isEqualTo(10000006L);
+        softly.assertThat(recepRow.getMessageSequenceNumber()).isEqualTo(expectedErrorMessageSequenceNumber);
         softly.assertThat(recepRow.getRecepCode()).isEqualTo(ReferenceMessageRecep.RecepCode.ERROR);
 
         recepRow = ReferenceMessageRecep.fromString("RFF+MIS:99000006 CI+ASD++");
 
-        softly.assertThat(recepRow.getMessageSequenceNumber()).isEqualTo(99000006L);
+        softly.assertThat(recepRow.getMessageSequenceNumber()).isEqualTo(expectedIncompleteMessageSequenceNumber);
         softly.assertThat(recepRow.getRecepCode()).isEqualTo(ReferenceMessageRecep.RecepCode.INCOMPLETE);
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceTransactionNumberTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceTransactionNumberTest.java
@@ -8,11 +8,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReferenceTransactionNumberTest {
+
+    private static final long TRANSACTION_NUMBER = 1234L;
+    private static final long MAX_TRANSACTION_SEQUENCE_NUMBER = 10_000_000L;
+    private static final long MAX_SEQUENCE_NUMBER = 99_999_999L;
+
     @Test
     public void testValidReferenceTransactionType() throws EdifactValidationException {
         ReferenceTransactionNumber referenceTransactionNumber =
                 new ReferenceTransactionNumber();
-        referenceTransactionNumber.setTransactionNumber(1234L);
+        referenceTransactionNumber.setTransactionNumber(TRANSACTION_NUMBER);
         String edifact = referenceTransactionNumber.toEdifact();
 
         assertEquals("RFF+TN:1234'", edifact);
@@ -27,7 +32,7 @@ public class ReferenceTransactionNumberTest {
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("RFF: Attribute transactionNumber must be between 1 and 9999999");
 
-        transactionNumber.setTransactionNumber(10_000_000L);
+        transactionNumber.setTransactionNumber(MAX_TRANSACTION_SEQUENCE_NUMBER);
         assertThatThrownBy(transactionNumber::validateStateful)
             .isInstanceOf(EdifactValidationException.class)
             .hasMessage("RFF: Attribute transactionNumber must be between 1 and 9999999");
@@ -35,7 +40,7 @@ public class ReferenceTransactionNumberTest {
         transactionNumber.setTransactionNumber(1L);
         transactionNumber.validateStateful();
 
-        transactionNumber.setTransactionNumber(9_999_999L);
+        transactionNumber.setTransactionNumber(MAX_SEQUENCE_NUMBER);
         transactionNumber.validateStateful();
     }
 
@@ -43,7 +48,7 @@ public class ReferenceTransactionNumberTest {
     void testFromString() {
         ReferenceTransactionNumber referenceTransactionNumber =
             new ReferenceTransactionNumber();
-        referenceTransactionNumber.setTransactionNumber(1234L);
+        referenceTransactionNumber.setTransactionNumber(TRANSACTION_NUMBER);
 
         assertThat(ReferenceTransactionNumber.fromString("RFF+TN:1234").getValue()).isEqualTo(referenceTransactionNumber.getValue());
         assertThatThrownBy(() -> ReferenceTransactionNumber.fromString("wrong value")).isExactlyInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceTransactionNumberTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceTransactionNumberTest.java
@@ -11,7 +11,7 @@ public class ReferenceTransactionNumberTest {
 
     private static final long TRANSACTION_NUMBER = 1234L;
     private static final long MAX_TRANSACTION_SEQUENCE_NUMBER = 10_000_000L;
-    private static final long MAX_SEQUENCE_NUMBER = 99_999_999L;
+    private static final long MAX_SEQUENCE_NUMBER = 9_999_999L;
 
     @Test
     public void testValidReferenceTransactionType() throws EdifactValidationException {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceTransactionTypeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/ReferenceTransactionTypeTest.java
@@ -47,8 +47,8 @@ public class ReferenceTransactionTypeTest {
             .build();
 
         assertThat(abbreviationMap).hasSize(
-            ReferenceTransactionType.Inbound.values().length +
-                ReferenceTransactionType.Outbound.values().length);
+            ReferenceTransactionType.Inbound.values().length + ReferenceTransactionType.Outbound.values().length
+        );
 
         abbreviationMap.forEach((abbreviation, transactionType) ->
             assertThat(ReferenceTransactionType.TransactionType.fromAbbreviation(abbreviation)).isEqualTo(transactionType));
@@ -72,8 +72,8 @@ public class ReferenceTransactionTypeTest {
             .build();
 
         assertThat(codeMap).hasSize(
-            ReferenceTransactionType.Inbound.values().length +
-                ReferenceTransactionType.Outbound.values().length);
+            ReferenceTransactionType.Inbound.values().length + ReferenceTransactionType.Outbound.values().length
+        );
 
         codeMap.forEach((code, transactionType) ->
             assertThat(ReferenceTransactionType.TransactionType.fromCode(code)).isEqualTo(transactionType));

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RegistrationMessageDateTimeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RegistrationMessageDateTimeTest.java
@@ -12,10 +12,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class RegistrationMessageDateTimeTest {
 
-    private final Instant WINTER = ZonedDateTime
+    private static final Instant WINTER = ZonedDateTime
         .of(2020, 3, 28, 20, 58, 0, 0, ZoneOffset.UTC)
         .toInstant();
-    private final Instant SUMMER = ZonedDateTime
+    private static final Instant SUMMER = ZonedDateTime
         .of(2020, 5, 28, 20, 58, 0, 0, ZoneOffset.UTC)
         .toInstant();
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RegistrationMessageDateTimeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RegistrationMessageDateTimeTest.java
@@ -44,6 +44,7 @@ public class RegistrationMessageDateTimeTest {
 
     @Test
     void When_FromStringAndStringIsNotDTMSegment_Expect_ThrowsException() {
-        assertThatThrownBy(() -> RegistrationMessageDateTime.fromString("ABC+123:456:789'")).isExactlyInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> RegistrationMessageDateTime.fromString("ABC+123:456:789'"))
+            .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RegistrationMessageDateTimeTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/RegistrationMessageDateTimeTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.nhs.digital.nhsconnect.nhais.model.edifact.message.EdifactValidationException;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
@@ -13,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class RegistrationMessageDateTimeTest {
 
     private static final Instant WINTER = ZonedDateTime
-        .of(2020, 3, 28, 20, 58, 0, 0, ZoneOffset.UTC)
+        .of(LocalDateTime.parse("2020-03-28T20:58:00"), ZoneOffset.UTC)
         .toInstant();
     private static final Instant SUMMER = ZonedDateTime
-        .of(2020, 5, 28, 20, 58, 0, 0, ZoneOffset.UTC)
+        .of(LocalDateTime.parse("2020-05-28T20:58:00"), ZoneOffset.UTC)
         .toInstant();
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/SegmentGroupTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/SegmentGroupTest.java
@@ -23,7 +23,8 @@ public class SegmentGroupTest {
 
     @Test
     public void testValidationStateful() {
-        SegmentGroup segmentGroup = new SegmentGroup(3);
+        final int segmentGroupNumber = 3;
+        SegmentGroup segmentGroup = new SegmentGroup(segmentGroupNumber);
 
         Exception exception = assertThrows(EdifactValidationException.class, segmentGroup::preValidate);
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/message/SplitTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/model/edifact/message/SplitTest.java
@@ -5,8 +5,6 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.nhs.digital.nhsconnect.nhais.model.edifact.message.Split.byColon;
 import static uk.nhs.digital.nhsconnect.nhais.model.edifact.message.Split.byPlus;
 import static uk.nhs.digital.nhsconnect.nhais.model.edifact.message.Split.bySegmentTerminator;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/ConversationIdHeadersTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/ConversationIdHeadersTest.java
@@ -1,5 +1,6 @@
 package uk.nhs.digital.nhsconnect.nhais.outbound.controller;
 
+import org.apache.http.HttpStatus;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public class ConversationIdHeadersTest {
             .contentType("text/plain")
             .header("ConversationId", "asdf1234")
             .content("qwe"))
-            .andExpect(status().is(415))
+            .andExpect(status().is(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE))
             .andExpect(header().string("ConversationId", "asdf1234"));
     }
 
@@ -55,7 +56,7 @@ public class ConversationIdHeadersTest {
         mockMvc.perform(post("/fhir/Patient/$nhais.acceptance")
             .contentType("text/plain")
             .content("qwe"))
-            .andExpect(status().is(415))
+            .andExpect(status().is(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE))
             .andExpect(header().string("ConversationId", Matchers.matchesRegex("[0-9A-F]{32}")));
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.MeshMessage;
@@ -162,7 +163,7 @@ public class FhirControllerTest {
         mockMvc.perform(post("/fhir/Patient/$nhais.acceptance")
             .contentType("text/plain")
             .content("qwe"))
-            .andExpect(status().is(415))
+            .andExpect(status().is(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value()))
             .andExpect(content().json(expectedResponse));
 
         var operationOutcomeArgumentCaptor = ArgumentCaptor.forClass(OperationOutcome.class);

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/OperationOutcomeExceptionHandlerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/OperationOutcomeExceptionHandlerTest.java
@@ -51,7 +51,7 @@ public class OperationOutcomeExceptionHandlerTest extends ResponseEntityExceptio
 
     private static class StubOperationOutcomeError extends Exception implements OperationOutcomeError {
 
-        public StubOperationOutcomeError(String message) {
+        StubOperationOutcomeError(String message) {
             super(message);
         }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/fhir/FhirParserTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/fhir/FhirParserTest.java
@@ -22,7 +22,7 @@ public class FhirParserTest {
     }
 
     @Test
-    public void When_ParseNotJson_Expect_ReturnFhirValidationException(){
+    public void When_ParseNotJson_Expect_ReturnFhirValidationException() {
         String xml = "<item></item>";
         assertThatThrownBy(() -> fhirParser.parseParameters(xml)).isExactlyInstanceOf(FhirValidationException.class);
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/fhir/FhirToEdifactServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/fhir/FhirToEdifactServiceTest.java
@@ -131,16 +131,17 @@ public class FhirToEdifactServiceTest {
 
         OutboundMeshMessage meshMessage = fhirToEdifactService.convertToEdifact(patient, ReferenceTransactionType.Outbound.ACCEPTANCE);
 
-        String expected = "UNB+UNOA:2+GP123+HA41+200427:1737+00000045'\n" +
-            "UNH+00000056+FHSREG:0:1:FH:FHS001'\n" +
-            "BGM+++507'\n" +
-            "NAD+FHS+HA4:954'\n" +
-            "DTM+137:202004271737:203'\n" +
-            "RFF+950:G1'\n" +
-            "S01+1'\n" +
-            "RFF+TN:5174'\n" +
-            "UNT+8+00000056'\n" +
-            "UNZ+1+00000045'";
+        String expected = """
+            UNB+UNOA:2+GP123+HA41+200427:1737+00000045'
+            UNH+00000056+FHSREG:0:1:FH:FHS001'
+            BGM+++507'
+            NAD+FHS+HA4:954'
+            DTM+137:202004271737:203'
+            RFF+950:G1'
+            S01+1'
+            RFF+TN:5174'
+            UNT+8+00000056'
+            UNZ+1+00000045'""";
 
         assertThat(meshMessage.getContent()).isEqualTo(expected);
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/fhir/FhirToEdifactServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/fhir/FhirToEdifactServiceTest.java
@@ -31,6 +31,7 @@ import uk.nhs.digital.nhsconnect.nhais.utils.ConversationIdService;
 import uk.nhs.digital.nhsconnect.nhais.utils.TimestampService;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 
@@ -85,7 +86,7 @@ public class FhirToEdifactServiceTest {
         when(sequenceService.generateInterchangeSequence(GP_TRADING_PARTNER_CODE, HA_TRADING_PARTNER_CODE)).thenReturn(SIS);
         when(sequenceService.generateTransactionNumber(GP_TRADING_PARTNER_CODE)).thenReturn(TN);
         expectedTimestamp = ZonedDateTime
-            .of(2020, 4, 27, 17, 37, 0, 0, TimestampService.UK_ZONE)
+            .of(LocalDateTime.parse("2020-04-27T17:37:00"), TimestampService.UK_ZONE)
             .toInstant();
         when(timestampService.getCurrentTimestamp()).thenReturn(expectedTimestamp);
         // segments related to state management only

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/DeductionDateMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/DeductionDateMapperTest.java
@@ -9,7 +9,6 @@ import uk.nhs.digital.nhsconnect.nhais.model.fhir.ParameterNames;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DeductionDateMapperTest {
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/DeductionReasonCodeMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/DeductionReasonCodeMapperTest.java
@@ -9,8 +9,6 @@ import uk.nhs.digital.nhsconnect.nhais.model.fhir.ParameterNames;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DeductionReasonCodeMapperTest {
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/PersonDateOfBirthMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/PersonDateOfBirthMapperTest.java
@@ -16,8 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PersonDateOfBirthMapperTest {
-    private static final LocalDate FIXED_TIME = LocalDate.of(1991, 11, 6);
-    private static final Instant FIXED_TIME_LOCAL = LocalDate.of(1991, 11, 6)
+    private static final LocalDate FIXED_TIME = LocalDate.parse("1991-11-06");
+    private static final Instant FIXED_TIME_LOCAL = LocalDate.parse("1991-11-06")
         .atStartOfDay(ZoneId.systemDefault())
         .toInstant();
     private final PersonDateOfBirthMapper personDateOfBirthMapper = new PersonDateOfBirthMapper();

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/PersonDateOfExitMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/PersonDateOfExitMapperTest.java
@@ -49,8 +49,8 @@ class PersonDateOfExitMapperTest {
     public void When_MappingWithoutDateParam_Expect_FhirValidationExceptionIsThrown() {
         Parameters parameters = new Parameters();
 
-        var PersonDateOfExitMapper = new PersonDateOfExitMapper();
-        assertThatThrownBy(() -> PersonDateOfExitMapper.map(parameters))
+        var personDateOfExitMapper = new PersonDateOfExitMapper();
+        assertThatThrownBy(() -> personDateOfExitMapper.map(parameters))
             .isExactlyInstanceOf(FhirValidationException.class);
     }
 

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/PersonPreviousNameMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/PersonPreviousNameMapperTest.java
@@ -20,18 +20,18 @@ class PersonPreviousNameMapperTest {
     public static final String FAMILY_NAME = "Smith";
     public static final String FAMILY_NAME_2 = "Kowalski";
 
-    public static final PatientName patientName = PatientName.builder()
+    public static final PatientName PATIENT_NAME = PatientName.builder()
         .familyName(FAMILY_NAME)
         .build();
 
-    public static final PatientName patientName2 = PatientName.builder()
+    public static final PatientName PATIENT_NAME_2 = PatientName.builder()
         .familyName(FAMILY_NAME_2)
         .build();
 
     @Test
     void When_MappingPatientPreviousFamilyName_Expect_ExpectCorrectResult() {
         Patient patient = new Patient()
-            .setName(List.of(patientName, patientName2))
+            .setName(List.of(PATIENT_NAME, PATIENT_NAME_2))
             .setIdentifier(List.of(new NhsIdentifier(NHS_NUMBER)));
 
         Parameters parameters = new Parameters()
@@ -102,7 +102,7 @@ class PersonPreviousNameMapperTest {
     @Test
     void When_MappingWithoutNhsNumber_Expect_ExpectCorrectResult() {
         Patient patient = new Patient()
-            .setName(List.of(patientName, patientName2));
+            .setName(List.of(PATIENT_NAME, PATIENT_NAME_2));
 
         Parameters parameters = new Parameters()
             .addParameter(new PatientParameter(patient));
@@ -128,7 +128,7 @@ class PersonPreviousNameMapperTest {
     @Test
     void When_ThereIsOnlyOneName_Expect_CanNotMap() {
         Patient patient = new Patient()
-            .setName(List.of(patientName));
+            .setName(List.of(PATIENT_NAME));
 
         Parameters parameters = new Parameters()
             .addParameter(new PatientParameter(patient));
@@ -141,7 +141,7 @@ class PersonPreviousNameMapperTest {
     @Test
     void When_ThereAreTwoNamea_Expect_CanMap() {
         Patient patient = new Patient()
-            .setName(List.of(patientName, patientName2));
+            .setName(List.of(PATIENT_NAME, PATIENT_NAME_2));
 
         Parameters parameters = new Parameters()
             .addParameter(new PatientParameter(patient));

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/PreviousHealthAuthorityNameMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/mapper/PreviousHealthAuthorityNameMapperTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PreviousHealthAuthorityNameMapperTest {
 
-    private final static String IDENTIFIER = "ID1";
+    private static final String IDENTIFIER = "ID1";
 
     @Test
     void When_MappingGPPrevious_Expect_ExpectCorrectResult() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/RemovalTranslatorTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/RemovalTranslatorTest.java
@@ -35,6 +35,16 @@ import static org.mockito.Mockito.when;
 @ExtendWith({MockitoExtension.class, SoftAssertionsExtension.class})
 public class RemovalTranslatorTest {
 
+    private static final int BEGINNING_OF_MESSAGE_INDEX = 0;
+    private static final int PARTY_QUALIFIER_INDEX = 1;
+    private static final int DATETIME_INDEX = 2;
+    private static final int INDEX = 3;
+    private static final int FIRST_SEGMENT_GROUP_INDEX = 4;
+    private static final int TRANSACTION_NUMBER = 5;
+    private static final int GP_ADDRESS_INDEX = 6;
+    private static final int FREE_TEXT_INDEX = 7;
+    private static final int SECOND_SENGMENT_GROUP_INDEX = 8;
+    private static final int PERSON_NAME_INDEX = 9;
     @Mock
     private PartyQualifierMapper partyQualifierMapper;
 
@@ -79,6 +89,8 @@ public class RemovalTranslatorTest {
 
     @Test
     void When_FhirRemovalIsTranslated_Expect_AllRequiredSegmentsArePresentAndAreOfCorrectType(SoftAssertions softly) {
+        final int expectedSegmentCount = 10;
+
         when(validator.nhsNumberIsMissing(any())).thenReturn(false);
         when(partyQualifierMapper.map(parameters)).thenReturn(partyQualifier);
         when(gpNameAndAddressMapper.map(parameters)).thenReturn(gpNameAndAddress);
@@ -87,17 +99,17 @@ public class RemovalTranslatorTest {
 
         List<Segment> segments = removalTranslator.translate(parameters);
 
-        softly.assertThat(segments.size()).isEqualTo(10);
+        softly.assertThat(segments.size()).isEqualTo(expectedSegmentCount);
 
-        softly.assertThat(segments.get(0)).isExactlyInstanceOf(BeginningOfMessage.class);
-        softly.assertThat(segments.get(1)).isEqualTo(partyQualifier);
-        softly.assertThat(segments.get(2)).isExactlyInstanceOf(RegistrationMessageDateTime.class);
-        softly.assertThat(segments.get(3)).isExactlyInstanceOf(ReferenceTransactionType.class);
-        softly.assertThat(segments.get(4)).isExactlyInstanceOf(SegmentGroup.class);
-        softly.assertThat(segments.get(5)).isExactlyInstanceOf(ReferenceTransactionNumber.class);
-        softly.assertThat(segments.get(6)).isEqualTo(gpNameAndAddress);
-        softly.assertThat(segments.get(7)).isEqualTo(freeText);
-        softly.assertThat(segments.get(8)).isExactlyInstanceOf(SegmentGroup.class);
-        softly.assertThat(segments.get(9)).isEqualTo(personName);
+        softly.assertThat(segments.get(BEGINNING_OF_MESSAGE_INDEX)).isExactlyInstanceOf(BeginningOfMessage.class);
+        softly.assertThat(segments.get(PARTY_QUALIFIER_INDEX)).isEqualTo(partyQualifier);
+        softly.assertThat(segments.get(DATETIME_INDEX)).isExactlyInstanceOf(RegistrationMessageDateTime.class);
+        softly.assertThat(segments.get(INDEX)).isExactlyInstanceOf(ReferenceTransactionType.class);
+        softly.assertThat(segments.get(FIRST_SEGMENT_GROUP_INDEX)).isExactlyInstanceOf(SegmentGroup.class);
+        softly.assertThat(segments.get(TRANSACTION_NUMBER)).isExactlyInstanceOf(ReferenceTransactionNumber.class);
+        softly.assertThat(segments.get(GP_ADDRESS_INDEX)).isEqualTo(gpNameAndAddress);
+        softly.assertThat(segments.get(FREE_TEXT_INDEX)).isEqualTo(freeText);
+        softly.assertThat(segments.get(SECOND_SENGMENT_GROUP_INDEX)).isExactlyInstanceOf(SegmentGroup.class);
+        softly.assertThat(segments.get(PERSON_NAME_INDEX)).isEqualTo(personName);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentAddressToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentAddressToEdifactMapperTest.java
@@ -39,24 +39,24 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Override
     void setUp() {
         super.setUp();
-        lenient().when(amendmentBody.getNhsNumber()).thenReturn(NHS_NUMBER);
+        lenient().when(super.getAmendmentBody().getNhsNumber()).thenReturn(NHS_NUMBER);
     }
 
     @Test
     void When_ReplacingAllFiveAddressLinesFields_Expect_AllAddressLinesAreMapped() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REPLACE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(HOUSE_NAME))));
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(ROAD_NAME))));
-        when(jsonPatches.getLocality()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(LOCALITY))));
-        when(jsonPatches.getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(POST_TOWN))));
-        when(jsonPatches.getCounty()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(COUNTY))));
 
-        Optional<Segment> segments = translator.map(amendmentBody);
+        Optional<Segment> segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isNotEmpty().get()
             .isEqualTo(PersonAddress.builder()
@@ -71,18 +71,18 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Test
     void When_AddressLineIsnull_Expect_NullToBeMapperAsEmptyEdifactString() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REPLACE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(HOUSE_NAME))));
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(ROAD_NAME))));
-        when(jsonPatches.getLocality()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(null)));
-        when(jsonPatches.getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(null)));
-        when(jsonPatches.getCounty()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(null)));
 
-        Optional<Segment> segments = translator.map(amendmentBody);
+        Optional<Segment> segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isNotEmpty().get()
             .isEqualTo(PersonAddress.builder()
@@ -97,18 +97,18 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Test
     void When_RemovingFourAddressLinesFields_Expect_FourAddressLinesRemoved() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REMOVE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(REMOVE_INDICATOR))));
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(REMOVE_INDICATOR))));
-        when(jsonPatches.getLocality()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(REMOVE_INDICATOR))));
-        when(jsonPatches.getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REPLACE).setValue(AmendmentValue.from(POST_TOWN))));
-        when(jsonPatches.getCounty()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(REMOVE_INDICATOR))));
 
-        Optional<Segment> segments = translator.map(amendmentBody);
+        Optional<Segment> segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isNotEmpty().get()
             .isEqualTo(PersonAddress.builder()
@@ -123,17 +123,17 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Test
     void When_HouseNameMissing_Expect_ThrowsFhirValidationException() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REPLACE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.empty());
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.empty());
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(ROAD_NAME))));
-        when(jsonPatches.getLocality()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(LOCALITY))));
-        when(jsonPatches.getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(POST_TOWN))));
-        when(jsonPatches.getCounty()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(COUNTY))));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isExactlyInstanceOf(FhirValidationException.class)
             .hasMessage(ALL_FIVE_ADDRESS_LINES_NEEDED_MESSAGE);
     }
@@ -141,17 +141,17 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Test
     void When_NumberOrRoadNameMissing_Expect_ThrowsFhirValidationException() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REPLACE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(HOUSE_NAME))));
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.empty());
-        when(jsonPatches.getLocality()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.empty());
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(LOCALITY))));
-        when(jsonPatches.getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(POST_TOWN))));
-        when(jsonPatches.getCounty()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(COUNTY))));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isExactlyInstanceOf(FhirValidationException.class)
             .hasMessage(ALL_FIVE_ADDRESS_LINES_NEEDED_MESSAGE);
     }
@@ -159,17 +159,17 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Test
     void When_LocalityMissing_Expect_ThrowsFhirValidationException() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REPLACE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(HOUSE_NAME))));
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(ROAD_NAME))));
-        when(jsonPatches.getLocality()).thenReturn(Optional.empty());
-        when(jsonPatches.getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.empty());
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(POST_TOWN))));
-        when(jsonPatches.getCounty()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(COUNTY))));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isExactlyInstanceOf(FhirValidationException.class)
             .hasMessage(ALL_FIVE_ADDRESS_LINES_NEEDED_MESSAGE);
     }
@@ -177,17 +177,17 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Test
     void When_PostTownMissing_Expect_ThrowsFhirValidationException() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REPLACE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(HOUSE_NAME))));
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(ROAD_NAME))));
-        when(jsonPatches.getLocality()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(LOCALITY))));
-        when(jsonPatches.getPostTown()).thenReturn(Optional.empty());
-        when(jsonPatches.getCounty()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.empty());
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(COUNTY))));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isExactlyInstanceOf(FhirValidationException.class)
             .hasMessage(ALL_FIVE_ADDRESS_LINES_NEEDED_MESSAGE);
     }
@@ -195,17 +195,17 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Test
     void When_CountyMissing_Expect_ThrowsFhirValidationException() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REPLACE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(HOUSE_NAME))));
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(ROAD_NAME))));
-        when(jsonPatches.getLocality()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(LOCALITY))));
-        when(jsonPatches.getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(POST_TOWN))));
-        when(jsonPatches.getCounty()).thenReturn(Optional.empty());
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isExactlyInstanceOf(FhirValidationException.class)
             .hasMessage(ALL_FIVE_ADDRESS_LINES_NEEDED_MESSAGE);
     }
@@ -213,18 +213,18 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     @Test
     void When_RemoveForPostTown_Expect_ThrowsPatchValidationException() {
         AmendmentPatchOperation operation = AmendmentPatchOperation.REMOVE;
-        when(jsonPatches.getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getHouseName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(HOUSE_NAME))));
-        when(jsonPatches.getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getNumberOrRoadName()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(ROAD_NAME))));
-        when(jsonPatches.getLocality()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getLocality()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(LOCALITY))));
-        when(jsonPatches.getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPostTown()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(POST_TOWN))));
-        when(jsonPatches.getCounty()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getCounty()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(COUNTY))));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isExactlyInstanceOf(PatchValidationException.class)
             .hasMessage("Post town ('address/0/line/3') cannot be removed");
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentAddressToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentAddressToEdifactMapperTest.java
@@ -31,8 +31,6 @@ public class AmendmentAddressToEdifactMapperTest extends AmendmentFhirToEdifactT
     private static final String COUNTY = "KENT";
     private static final String EMPTY_STRING = "";
 
-    private static final String LOCALITY_POST_TOWN_AND_LOCALITY_INCONSISTENCY_MESSAGE = "If at least one of the Address - Locality, Address - Post Town and Address County " +
-        "fields is amended for a patient, then the values held for all three of these fields MUST be provided. Actual state: ";
     private static final String ALL_FIVE_ADDRESS_LINES_NEEDED_MESSAGE = "All five address lines must be provided for amendment";
 
     private final AmendmentAddressToEdifactMapper translator = new AmendmentAddressToEdifactMapper();

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentDateOfBirthToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentDateOfBirthToEdifactMapperTest.java
@@ -39,10 +39,10 @@ class AmendmentDateOfBirthToEdifactMapperTest extends AmendmentFhirToEdifactTest
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddingOrReplacingDateOfBirth_Expect_FieldsAreMapped(AmendmentPatchOperation operation) {
-        when(jsonPatches.getBirthDate()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getBirthDate()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(DATE_OF_BIRTH))));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(PersonDateOfBirth.builder()
@@ -52,10 +52,10 @@ class AmendmentDateOfBirthToEdifactMapperTest extends AmendmentFhirToEdifactTest
 
     @Test
     void When_UsingRemoveOperation_Expect_Exception() {
-        when(jsonPatches.getBirthDate()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getBirthDate()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Illegal remove operation on /birthDate");
     }
@@ -63,13 +63,13 @@ class AmendmentDateOfBirthToEdifactMapperTest extends AmendmentFhirToEdifactTest
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddOrReplaceValuesAreEmpty_Expect_Exception(AmendmentPatchOperation operation) {
-        when(jsonPatches.getBirthDate()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getBirthDate()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setPath(JsonPatches.BIRTH_DATE_PATH)
             .setValue(AmendmentValue.from(StringUtils.EMPTY))
         ));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Invalid values for: [/birthDate]");
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentDrugsDispensedMarkerToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentDrugsDispensedMarkerToEdifactMapperTest.java
@@ -27,11 +27,11 @@ class AmendmentDrugsDispensedMarkerToEdifactMapperTest extends AmendmentFhirToEd
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddingOrReplacingWithCorrectValue_Expect_FieldsAreMapped(AmendmentPatchOperation operation) {
-        when(jsonPatches.getDrugsDispensedMarker()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getDrugsDispensedMarker()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setValue(new AmendmentBooleanExtension.DrugsDispensedMarker(true))));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(new DrugsMarker(true));
@@ -40,11 +40,11 @@ class AmendmentDrugsDispensedMarkerToEdifactMapperTest extends AmendmentFhirToEd
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_Removing_Expect_FieldsAreRemoved(AmendmentPatchOperation operation) {
-        when(jsonPatches.getDrugsDispensedMarker()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getDrugsDispensedMarker()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setValue(new AmendmentBooleanExtension.DrugsDispensedMarker(false))));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(new DrugsMarker(false));
@@ -52,10 +52,10 @@ class AmendmentDrugsDispensedMarkerToEdifactMapperTest extends AmendmentFhirToEd
 
     @Test
     void When_UsingRemoveOperation_Expect_Exception() {
-        when(jsonPatches.getDrugsDispensedMarker()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getDrugsDispensedMarker()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Removing Drugs Dispensed Marker should be done using extension with 'false' value");
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentFhirToEdifactTestBase.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentFhirToEdifactTestBase.java
@@ -1,5 +1,6 @@
 package uk.nhs.digital.nhsconnect.nhais.outbound.translator.amendment.mappers;
 
+import lombok.Getter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.Mock;
@@ -12,14 +13,15 @@ import java.util.stream.Stream;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+@Getter
 public class AmendmentFhirToEdifactTestBase {
     protected static final String REMOVE_INDICATOR = "%";
 
     @Mock
-    protected AmendmentBody amendmentBody;
+    private AmendmentBody amendmentBody;
 
     @Mock
-    protected JsonPatches jsonPatches;
+    private JsonPatches jsonPatches;
 
     @SuppressWarnings("unused")
     protected static Stream<Arguments> getAddOrReplaceEnums() {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentFreeTextToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentFreeTextToEdifactMapperTest.java
@@ -30,9 +30,9 @@ class AmendmentFreeTextToEdifactMapperTest extends AmendmentFhirToEdifactTestBas
 
     @Test
     void When_FreeTextIsPresent_Expect_ValueIsMapped() {
-        when(amendmentBody.getFreeText()).thenReturn(FREE_TEXT);
+        when(super.getAmendmentBody().getFreeText()).thenReturn(FREE_TEXT);
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(new FreeText(FREE_TEXT));
@@ -41,9 +41,9 @@ class AmendmentFreeTextToEdifactMapperTest extends AmendmentFhirToEdifactTestBas
     @ParameterizedTest
     @MethodSource(value = "getEmptyValues")
     void When_FreeTextIsEmpty_Expect_ValueIsMapped(String value) {
-        when(amendmentBody.getFreeText()).thenReturn(value);
+        when(super.getAmendmentBody().getFreeText()).thenReturn(value);
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isEmpty();
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentNameToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentNameToEdifactMapperTest.java
@@ -44,24 +44,24 @@ class AmendmentNameToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
     @Override
     void setUp() {
         super.setUp();
-        lenient().when(amendmentBody.getNhsNumber()).thenReturn(NHS_NUMBER);
+        lenient().when(super.getAmendmentBody().getNhsNumber()).thenReturn(NHS_NUMBER);
     }
 
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddingOrReplacingAllFields_Expect_AllFieldsAreMapped(AmendmentPatchOperation operation) {
-        when(jsonPatches.getSurname()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSurname()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(SURNAME))));
-        when(jsonPatches.getFirstForename()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getFirstForename()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(FIRST_FORENAME))));
-        when(jsonPatches.getSecondForename()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSecondForename()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(SECOND_FORENAME))));
-        when(jsonPatches.getOtherForenames()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getOtherForenames()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(OTHER_FORENAMES))));
-        when(jsonPatches.getTitle()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getTitle()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(TITLE))));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isNotEmpty().get()
             .isEqualTo(PersonName.builder()
@@ -77,12 +77,12 @@ class AmendmentNameToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
 
     @Test
     void When_RemovingAllFields_Expect_AllFieldsAreMapped() {
-        when(jsonPatches.getAllForenamesPath()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getAllForenamesPath()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)));
-        when(jsonPatches.getTitle()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getTitle()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isNotEmpty().get()
             .isEqualTo(PersonName.builder()
@@ -95,10 +95,10 @@ class AmendmentNameToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
 
     @Test
     void When_RemovingSurname_Expect_Exception() {
-        when(jsonPatches.getSurname()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSurname()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Removing surnames is illegal");
     }
@@ -107,18 +107,18 @@ class AmendmentNameToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_RemovingAllForenamesAndModifyingAtTheSameTime_Expect_Exception(AmendmentPatchOperation operation, SoftAssertions softly) {
         Stream.<Supplier<Optional<AmendmentPatch>>>of(
-            jsonPatches::getFirstForename,
-            jsonPatches::getSecondForename,
-            jsonPatches::getOtherForenames)
+            super.getJsonPatches()::getFirstForename,
+            super.getJsonPatches()::getSecondForename,
+            super.getJsonPatches()::getOtherForenames)
             .forEach(patchSupplier -> {
-                reset(jsonPatches);
+                reset(super.getJsonPatches());
                 when(patchSupplier.get()).thenReturn(Optional.of(new AmendmentPatch()
                     .setValue(AmendmentValue.from("some_value"))
                     .setOp(operation)));
-                when(jsonPatches.getAllForenamesPath()).thenReturn(Optional.of(new AmendmentPatch()
+                when(super.getJsonPatches().getAllForenamesPath()).thenReturn(Optional.of(new AmendmentPatch()
                     .setOp(operation)));
 
-                softly.assertThatThrownBy(() -> translator.map(amendmentBody))
+                softly.assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
                     .isInstanceOf(PatchValidationException.class)
                     .hasMessage("Illegal to modify forenames and remove all at the same time");
             });
@@ -126,27 +126,27 @@ class AmendmentNameToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
 
     @Test
     void When_RemovingAnyForename_Expect_Exception(SoftAssertions softly) {
-        reset(jsonPatches);
-        when(jsonPatches.getFirstForename()).thenReturn(Optional.of(new AmendmentPatch()
+        reset(super.getJsonPatches());
+        when(super.getJsonPatches().getFirstForename()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)
             .setPath(JsonPatches.FIRST_FORENAME_PATH)));
-        softly.assertThatThrownBy(() -> translator.map(amendmentBody))
+        softly.assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Removing /name/0/given/0 is illegal. Use /name/0/given to remove all forenames instead");
 
-        reset(jsonPatches);
-        when(jsonPatches.getSecondForename()).thenReturn(Optional.of(new AmendmentPatch()
+        reset(super.getJsonPatches());
+        when(super.getJsonPatches().getSecondForename()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)
             .setPath(JsonPatches.SECOND_FORENAME_PATH)));
-        softly.assertThatThrownBy(() -> translator.map(amendmentBody))
+        softly.assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Removing /name/0/given/1 is illegal. Use /name/0/given to remove all forenames instead");
 
-        reset(jsonPatches);
-        when(jsonPatches.getOtherForenames()).thenReturn(Optional.of(new AmendmentPatch()
+        reset(super.getJsonPatches());
+        when(super.getJsonPatches().getOtherForenames()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)
             .setPath(JsonPatches.OTHER_FORENAMES_PATH)));
-        softly.assertThatThrownBy(() -> translator.map(amendmentBody))
+        softly.assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Removing /name/0/given/2 is illegal. Use /name/0/given to remove all forenames instead");
     }
@@ -154,28 +154,28 @@ class AmendmentNameToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddOrReplaceValuesAreEmpty_Expect_Exception(AmendmentPatchOperation operation) {
-        when(jsonPatches.getTitle()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getTitle()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setPath(JsonPatches.TITLE_PATH)
             .setValue(AmendmentValue.from(StringUtils.EMPTY))));
-        when(jsonPatches.getSurname()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSurname()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setPath(JsonPatches.SURNAME_PATH)
             .setValue(AmendmentValue.from(StringUtils.EMPTY))));
-        when(jsonPatches.getFirstForename()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getFirstForename()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setPath(JsonPatches.FIRST_FORENAME_PATH)
             .setValue(AmendmentValue.from(StringUtils.EMPTY))));
-        when(jsonPatches.getSecondForename()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSecondForename()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setPath(JsonPatches.SECOND_FORENAME_PATH)
             .setValue(AmendmentValue.from(StringUtils.EMPTY))));
-        when(jsonPatches.getOtherForenames()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getOtherForenames()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setPath(JsonPatches.OTHER_FORENAMES_PATH)
             .setValue(AmendmentValue.from(StringUtils.EMPTY))));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Invalid values for: [/name/0/prefix/0, /name/0/family, /name/0/given/0, /name/0/given/1, /name/0/given/2]");
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentPreviousNameToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentPreviousNameToEdifactMapperTest.java
@@ -30,10 +30,10 @@ class AmendmentPreviousNameToEdifactMapperTest extends AmendmentFhirToEdifactTes
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddingOrReplacingPreviousSurname_Expect_AllFieldsAreMapped(AmendmentPatchOperation operation) {
-        when(jsonPatches.getPreviousSurname()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPreviousSurname()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from(PREVIOUS_SURNAME))));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(PersonPreviousName.builder()
@@ -43,10 +43,10 @@ class AmendmentPreviousNameToEdifactMapperTest extends AmendmentFhirToEdifactTes
 
     @Test
     void When_RemovingPreviousSurname_Expect_AllFieldsAreMapped() {
-        when(jsonPatches.getPreviousSurname()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPreviousSurname()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(PersonPreviousName.builder()
@@ -57,13 +57,13 @@ class AmendmentPreviousNameToEdifactMapperTest extends AmendmentFhirToEdifactTes
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddOrReplaceValuesAreEmpty_Expect_Exception(AmendmentPatchOperation operation) {
-        when(jsonPatches.getPreviousSurname()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getPreviousSurname()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setPath(JsonPatches.PREVIOUS_SURNAME_PATH)
             .setValue(AmendmentValue.from(StringUtils.EMPTY))
         ));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Invalid values for: [/name/1/family]");
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentResidentialInstituteToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentResidentialInstituteToEdifactMapperTest.java
@@ -28,11 +28,11 @@ class AmendmentResidentialInstituteToEdifactMapperTest extends AmendmentFhirToEd
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddingOrReplacingWithCorrectValue_Expect_FieldsAreMapped(AmendmentPatchOperation operation) {
-        when(jsonPatches.getResidentialInstituteCode()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getResidentialInstituteCode()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setValue(new AmendmentStringExtension.ResidentialInstituteCode("null"))));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(new ResidentialInstituteNameAndAddress("null"));
@@ -41,11 +41,11 @@ class AmendmentResidentialInstituteToEdifactMapperTest extends AmendmentFhirToEd
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_Removing_Expect_FieldsAreRemoved(AmendmentPatchOperation operation) {
-        when(jsonPatches.getResidentialInstituteCode()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getResidentialInstituteCode()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setValue(new AmendmentStringExtension.ResidentialInstituteCode(null))));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(new ResidentialInstituteNameAndAddress("%"));
@@ -53,10 +53,10 @@ class AmendmentResidentialInstituteToEdifactMapperTest extends AmendmentFhirToEd
 
     @Test
     void When_UsingRemoveOperation_Expect_Exception() {
-        when(jsonPatches.getResidentialInstituteCode()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getResidentialInstituteCode()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Removing Residential Institute Code should be done using extension with 'null' value");
     }
@@ -64,12 +64,12 @@ class AmendmentResidentialInstituteToEdifactMapperTest extends AmendmentFhirToEd
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddOrReplaceValuesAreEmpty_Expect_Exception(AmendmentPatchOperation operation) {
-        when(jsonPatches.getResidentialInstituteCode()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getResidentialInstituteCode()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setValue(new AmendmentStringExtension.ResidentialInstituteCode(StringUtils.EMPTY))
         ));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("String value must not be empty");
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentSexToEdifactMapperTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/translator/amendment/mappers/AmendmentSexToEdifactMapperTest.java
@@ -30,10 +30,10 @@ class AmendmentSexToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddingOrReplacingWithCorrectValue_Expect_FieldsAreMapped(AmendmentPatchOperation operation) {
-        when(jsonPatches.getSex()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSex()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from("female"))));
 
-        var segments = translator.map(amendmentBody);
+        var segments = translator.map(super.getAmendmentBody());
 
         assertThat(segments).isPresent().get()
             .isEqualTo(PersonSex.builder()
@@ -44,20 +44,20 @@ class AmendmentSexToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddingOrReplacingWithIncorrectValue_Expect_Exception(AmendmentPatchOperation operation) {
-        when(jsonPatches.getSex()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSex()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation).setValue(AmendmentValue.from("qwe"))));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("No gender value for 'qwe'");
     }
 
     @Test
     void When_UsingRemoveOperation_Expect_Exception() {
-        when(jsonPatches.getSex()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSex()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(AmendmentPatchOperation.REMOVE)));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Illegal remove operation on /gender");
     }
@@ -65,13 +65,13 @@ class AmendmentSexToEdifactMapperTest extends AmendmentFhirToEdifactTestBase {
     @ParameterizedTest
     @MethodSource(value = "getAddOrReplaceEnums")
     void When_AddOrReplaceValuesAreEmpty_Expect_Exception(AmendmentPatchOperation operation) {
-        when(jsonPatches.getSex()).thenReturn(Optional.of(new AmendmentPatch()
+        when(super.getJsonPatches().getSex()).thenReturn(Optional.of(new AmendmentPatch()
             .setOp(operation)
             .setPath(JsonPatches.SEX_PATH)
             .setValue(AmendmentValue.from(StringUtils.EMPTY))
         ));
 
-        assertThatThrownBy(() -> translator.map(amendmentBody))
+        assertThatThrownBy(() -> translator.map(super.getAmendmentBody()))
             .isInstanceOf(PatchValidationException.class)
             .hasMessage("Invalid values for: [/gender]");
     }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/sequence/SequenceRepositoryTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/sequence/SequenceRepositoryTest.java
@@ -17,9 +17,9 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class SequenceRepositoryTest {
-    private final static String MAX_KEY = "max-key";
-    private final static String NEW_KEY = "new-key";
-    private final static OutboundSequenceId SEQUENCE_ID = new OutboundSequenceId(NEW_KEY, 1L);
+    private static final String MAX_KEY = "max-key";
+    private static final String NEW_KEY = "new-key";
+    private static final OutboundSequenceId SEQUENCE_ID = new OutboundSequenceId(NEW_KEY, 1L);
 
     @InjectMocks
     private SequenceRepository sequenceRepository;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/sequence/SequenceRepositoryTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/sequence/SequenceRepositoryTest.java
@@ -20,6 +20,8 @@ public class SequenceRepositoryTest {
     private static final String MAX_KEY = "max-key";
     private static final String NEW_KEY = "new-key";
     private static final OutboundSequenceId SEQUENCE_ID = new OutboundSequenceId(NEW_KEY, 1L);
+    private static final long MAX_KEY_OUT_OF_BOUNDS_VALUE = 100000001L;
+    private static final long MAX_KEY_VALUE = 100000000L;
 
     @InjectMocks
     private SequenceRepository sequenceRepository;
@@ -37,11 +39,12 @@ public class SequenceRepositoryTest {
 
     @Test
     public void When_GetMaxNextKey_Expect_ValueReset() {
+        final long expectedNextKey = 1L;
         when(mongoOperations.findAndModify(any(Query.class), any(Update.class), any(FindAndModifyOptions.class),
             eq(OutboundSequenceId.class)))
-            .thenReturn(new OutboundSequenceId(MAX_KEY, 100000000L))
-            .thenReturn(new OutboundSequenceId(MAX_KEY, 100000001L));
+            .thenReturn(new OutboundSequenceId(MAX_KEY, MAX_KEY_VALUE))
+            .thenReturn(new OutboundSequenceId(MAX_KEY, MAX_KEY_OUT_OF_BOUNDS_VALUE));
 
-        assertThat(sequenceRepository.getNext(MAX_KEY)).isEqualTo(1L);
+        assertThat(sequenceRepository.getNext(MAX_KEY)).isEqualTo(expectedNextKey);
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/sequence/SequenceServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/sequence/SequenceServiceTest.java
@@ -12,10 +12,10 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class SequenceServiceTest {
-    private final static String TRANSACTION_ID = "TN-sender";
-    private final static String INTERCHANGE_ID = "SIS-sender-recipient";
-    private final static String MESSAGE_ID = "SMS-sender-recipient";
-    private final static Long SEQ_VALUE = 1L;
+    private static final String TRANSACTION_ID = "TN-sender";
+    private static final String INTERCHANGE_ID = "SIS-sender-recipient";
+    private static final String MESSAGE_ID = "SMS-sender-recipient";
+    private static final Long SEQ_VALUE = 1L;
 
     @InjectMocks
     private SequenceService sequenceService;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/utils/OperationIdTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/utils/OperationIdTest.java
@@ -5,15 +5,16 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class OperationIdTest {
-
+    private static final long SOME_SENDER_TRANSACTION_NUMBER = 123L;
+    private static final long SOME_OTHER_SENDER_TRANSACTION_NUMBER = 234L;
     @Test
     void When_BuildingOperationId_Expect_HashIsCreated() {
         assertEquals(
             "5d6c5b2009aa0a3a88ca8bd8ba339df16a831c35196136cba56f13b742461231",
-            OperationId.buildOperationId("some_sender", 123L));
+            OperationId.buildOperationId("some_sender", SOME_SENDER_TRANSACTION_NUMBER));
 
         assertEquals(
             "0c8fc3217244a8a5ad21869bed877a73fc844eeb00d28ad72e936c19fac03455",
-            OperationId.buildOperationId("some_other_sender", 234L));
+            OperationId.buildOperationId("some_other_sender", SOME_OTHER_SENDER_TRANSACTION_NUMBER));
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/utils/PemFormatterTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/utils/PemFormatterTest.java
@@ -8,14 +8,25 @@ public class PemFormatterTest {
 
     @Test
     public void When_CertHasExtraWhitespace_Expect_ItIsTrimmed() {
-        String withWhitespace = " -----BEGIN CERTIFICATE-----\n " +
-            "    \t  MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV \n" +
-            "  \n\n    W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=\n" +
-            "   \r   -----END CERTIFICATE-----";
-        String trimmed = "-----BEGIN CERTIFICATE-----\n" +
-            "MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\n" +
-            "W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=\n" +
-            "-----END CERTIFICATE-----";
+
+        // this warning is suppressed as the extra whitespace (including trailing whitespace) is intentional
+        @SuppressWarnings("com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSingleLineCheck")
+        final String withWhitespace = """
+             -----BEGIN CERTIFICATE-----
+                MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV 
+                
+                
+                W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=
+            
+               -----END CERTIFICATE-----    
+            """;
+
+        final String trimmed = """
+        -----BEGIN CERTIFICATE-----
+        MIIFXzCCA0egAwIBAgIJALRbCSor9bEbMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
+        W/JNIRmhLoeFNGNh8HvhI2PwOCsFiqT1rrCaUtusTyH0Ggs=
+        -----END CERTIFICATE-----""";
+
         String formatted = PemFormatter.format(withWhitespace);
         assertThat(formatted).isEqualTo(trimmed);
         assertThat(formatted).isEqualTo(trimmed);
@@ -23,14 +34,18 @@ public class PemFormatterTest {
 
     @Test
     public void When_CertHasNoNewlines_Expect_ItIsReformatted() {
-        String withoutNewlines = "-----BEGIN RSA PRIVATE KEY-----" +
-            " MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5" +
-            " M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG" +
-            " -----END RSA PRIVATE KEY-----";
-        String trimmed = "-----BEGIN RSA PRIVATE KEY-----\n" +
-            "MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5\n" +
-            "M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG\n" +
-            "-----END RSA PRIVATE KEY-----";
+        String withoutNewlines =
+            "-----BEGIN RSA PRIVATE KEY-----"
+                + " MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5"
+                + " M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG"
+                + " -----END RSA PRIVATE KEY-----";
+
+        String trimmed = """
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5
+            M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG
+            -----END RSA PRIVATE KEY-----""";
+
         String formatted = PemFormatter.format(withoutNewlines);
         assertThat(formatted).isEqualTo(trimmed);
         assertThat(formatted).isEqualTo(trimmed);
@@ -38,14 +53,14 @@ public class PemFormatterTest {
 
     @Test
     public void When_CertUsesDifferentHeaderAndFormattedCorrectly_Expect_ItIsNotModified() {
-        String pem = "-----BEGIN PRIVATE KEY-----\n" +
-            "MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5\n" +
-            "M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG\n" +
-            "-----END PRIVATE KEY-----";
+        String pem = """
+            -----BEGIN PRIVATE KEY-----
+            MIIJKQIBAAKCAgEA0x7V2cpEuXbLxb4TFigeN6e/TViXx4B9LMuHwwENX1P5V3O5
+            M0d/fLCFruu5dU3PWKoU2rTzUkflj5XOzu2xAftYi3KDMzRR2sByxjjxb/qMIybG
+            -----END PRIVATE KEY-----""";
+
         String formatted = PemFormatter.format(pem);
         assertThat(formatted).isEqualTo(pem);
         assertThat(formatted).isEqualTo(pem);
     }
-
-
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/utils/TimestampServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/utils/TimestampServiceTest.java
@@ -7,17 +7,21 @@ import java.time.Instant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TimestampServiceTest {
+
+    private static final int MILLISECOND_MULTIPLIER = 1000000;
+    private static final int EPOCH_SECONDS = 123123;
+
     @Test
     public void When_GettingTimestamp_Expect_PrecisionIsMilliseconds() {
         var instant = new TimestampService().getCurrentTimestamp();
-        long remainder = instant.getNano() % 1000000; // nanoseconds per millisecond
+        long remainder = instant.getNano() % MILLISECOND_MULTIPLIER; // nanoseconds per millisecond
 
         assertThat(remainder).isEqualTo(0);
     }
 
     @Test
     public void When_FormattingInISO_Expect_ISOForUKZoneIsReturned() {
-        Instant timestamp = Instant.ofEpochSecond(123123);
+        Instant timestamp = Instant.ofEpochSecond(EPOCH_SECONDS);
 
         assertThat(new TimestampService().formatInISO(timestamp)).isEqualTo("1970-01-02T11:12:03+01:00[Europe/London]");
     }


### PR DESCRIPTION
* Address CheckStyle [UnusedImport] issues (Unused Import.)
* Address CheckStyle [RedundantImport] issues (Redundant import from the same package.)
* Address CheckStyle [AvoidStarImport] issues (Using the '.*' form of import should be avoided.)
* Address CheckStyle [OperatorWrap] issues ('+' should be on a new line.)
* Removed unused constant highlighted by [OperatorWrap] issue.
* Address CheckStyle [ModifierOrder] issues ('<Modifier>' out of order with the JLS suggestions.)
* Address CheckStyle [WhitespaceAfter] issues ('*' is not followed by whitespace.)
* Address CheckStyle [WhitespaceAround] issues ('*' is not preceded with whitespace.)
* Address CheckStyle [ParenPad] issues ('*' is followed by whitespace.)
*Address CheckStyle [MemberName] issues (Name '<Name>' must match pattern '*'.)
* Address CheckStyle [MagicNumber] issues ('*' is a magic number) by replacing date construction with a parsed ISO string.
* Address remaining CheckStyle [MagicNumber] issues ('*' is a magic number.)
* Address CheckStyle [LineLength] issues (Line is longer than 140 characters.)
* Address CheckStyle [RedundantModifier] issues (Redundant `<Modifier>` modifier.)
* Address CheckStyle [VisibilityModifier] issues (Variable '<VariableName>' must be private and have accessor methods.)