### PR TITLE
Fix issue with `main` branch reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             GIT_BRANCH=PR
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            GIT_BRANCH=main
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            GIT_BRANCH=develop
           fi
 
           BUILD_ID=$(./create_build_id.sh $GIT_BRANCH ${{ github.run_number }} ${{ github.sha }})


### PR DESCRIPTION
* For NHAIS the `main` branch is currently `develop` but this is not correctly referenced when generating buildId.