### PR TITLE
NIAD-3351: Replace obsolete `@MockBean` and `@SpyBean`

### DIFF
--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/DeadLetterQueueTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/DeadLetterQueueTest.java
@@ -3,8 +3,8 @@ package uk.nhs.digital.nhsconnect.nhais.inbound;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import uk.nhs.digital.nhsconnect.nhais.IntegrationBaseTest;
 import uk.nhs.digital.nhsconnect.nhais.mesh.http.MeshClient;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.OutboundMeshMessage;
@@ -27,10 +27,10 @@ public class DeadLetterQueueTest extends IntegrationBaseTest {
     @Autowired
     private OutboundQueueService outboundQueueService;
 
-    @SpyBean
+    @MockitoSpyBean
     private MeshClient meshClient;
 
-    @SpyBean
+    @MockitoSpyBean
     private ConversationIdService conversationIdService;
 
     @Autowired

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.nhs.digital.nhsconnect.nhais.IntegrationBaseTest;
 import uk.nhs.digital.nhsconnect.nhais.inbound.state.InboundState;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.MeshMessage;
@@ -81,7 +81,7 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
     private static final String ISO_GENERATED_TIMESTAMP = new TimestampService()
         .formatInISO(GENERATED_TIMESTAMP);
 
-    @MockBean
+    @MockitoBean
     private TimestampService timestampService;
 
     @Value("classpath:edifact/multi_transaction.1.dat")

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueRecepTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueRecepTest.java
@@ -5,9 +5,9 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.nhs.digital.nhsconnect.nhais.IntegrationBaseTest;
 import uk.nhs.digital.nhsconnect.nhais.inbound.state.InboundState;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.MeshMessage;
@@ -50,10 +50,10 @@ public class InboundMeshQueueRecepTest extends IntegrationBaseTest {
     @Value("classpath:edifact/recep.dat")
     private Resource recep;
 
-    @MockBean
+    @MockitoBean
     private TimestampService timestampService;
 
-    @MockBean
+    @MockitoBean
     private ConversationIdService conversationIdService;
 
     @BeforeEach

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueRegistrationTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueRegistrationTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.nhs.digital.nhsconnect.nhais.IntegrationBaseTest;
 import uk.nhs.digital.nhsconnect.nhais.inbound.state.InboundState;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.MeshMessage;
@@ -51,7 +51,7 @@ public class InboundMeshQueueRegistrationTest extends IntegrationBaseTest {
     private static final String ISO_GENERATED_TIMESTAMP = new TimestampService()
         .formatInISO(GENERATED_TIMESTAMP);
 
-    @MockBean
+    @MockitoBean
     private TimestampService timestampService;
     @Value("classpath:edifact/registration.dat")
     private Resource interchange;

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/OutboundUserAcceptanceTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/outbound/OutboundUserAcceptanceTest.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.nhs.digital.nhsconnect.nhais.IntegrationBaseTest;
@@ -48,7 +48,7 @@ public class OutboundUserAcceptanceTest extends IntegrationBaseTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @SpyBean
+    @MockitoSpyBean
     private TimestampService timestampService;
 
     private String conversationId;

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/configuration/ConversationIdFilterConfig.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/configuration/ConversationIdFilterConfig.java
@@ -9,9 +9,8 @@ import uk.nhs.digital.nhsconnect.nhais.outbound.ConversationIdFilter;
 public class ConversationIdFilterConfig {
 
     @Bean
-    public FilterRegistrationBean<ConversationIdFilter> servletRegistrationBean() {
+    public FilterRegistrationBean<ConversationIdFilter> servletRegistrationBean(ConversationIdFilter conversationIdFilter) {
         final FilterRegistrationBean<ConversationIdFilter> registrationBean = new FilterRegistrationBean<>();
-        final ConversationIdFilter conversationIdFilter = new ConversationIdFilter();
         registrationBean.setFilter(conversationIdFilter);
         registrationBean.setOrder(2);
         return registrationBean;

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/ConversationIdFilter.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/outbound/ConversationIdFilter.java
@@ -4,13 +4,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import uk.nhs.digital.nhsconnect.nhais.utils.ConversationIdService;
 
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,12 +19,15 @@ public class ConversationIdFilter extends OncePerRequestFilter {
 
     static final String HEADER_NAME = "ConversationId";
 
-    private ConversationIdService conversationIdService;
+    private final ConversationIdService conversationIdService;
+
+    public ConversationIdFilter(ConversationIdService conversationIdService) {
+        this.conversationIdService = conversationIdService;
+    }
 
     @Override
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain chain)
         throws java.io.IOException, ServletException {
-        lazyInitialize(request);
         try {
             var token = request.getHeader(HEADER_NAME);
             if (StringUtils.isEmpty(token)) {
@@ -39,14 +39,6 @@ public class ConversationIdFilter extends OncePerRequestFilter {
             chain.doFilter(request, response);
         } finally {
             conversationIdService.resetConversationId();
-        }
-    }
-
-    private void lazyInitialize(HttpServletRequest request) {
-        if (conversationIdService == null) {
-            ServletContext servletContext = request.getServletContext();
-            WebApplicationContext webApplicationContext = WebApplicationContextUtils.getWebApplicationContext(servletContext);
-            this.conversationIdService = webApplicationContext.getBean(ConversationIdService.class);
         }
     }
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/AmendmentControllerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/AmendmentControllerTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,7 +49,7 @@ public class AmendmentControllerTest {
     @MockitoBean
     private ObjectMapper objectMapper;
 
-    @MockitoSpyBean
+    @MockitoBean
     private ConversationIdService conversationIdService;
 
     @MockitoBean

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/AmendmentControllerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/AmendmentControllerTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.io.Resource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,19 +41,19 @@ public class AmendmentControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private JsonPatchToEdifactService jsonPatchToEdifactService;
 
-    @MockBean
+    @MockitoBean
     private OutboundQueueService outboundQueueService;
 
-    @MockBean
+    @MockitoBean
     private ObjectMapper objectMapper;
 
-    @SpyBean
+    @MockitoSpyBean
     private ConversationIdService conversationIdService;
 
-    @MockBean
+    @MockitoBean
     private FhirParser fhirParser;
 
     @Value("classpath:/amendment/amendment.json")

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/ConversationIdHeadersTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/ConversationIdHeadersTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.digital.nhsconnect.nhais.outbound.OutboundQueueService;
@@ -38,7 +37,7 @@ public class ConversationIdHeadersTest {
     @MockitoBean
     private FhirToEdifactService fhirToEdifactService;
 
-    @MockitoSpyBean
+    @MockitoBean
     private ConversationIdService conversationIdService;
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/ConversationIdHeadersTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/ConversationIdHeadersTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.digital.nhsconnect.nhais.outbound.OutboundQueueService;
@@ -29,16 +29,16 @@ public class ConversationIdHeadersTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private FhirParser fhirParser;
 
-    @MockBean
+    @MockitoBean
     private OutboundQueueService outboundQueueService;
 
-    @MockBean
+    @MockitoBean
     private FhirToEdifactService fhirToEdifactService;
 
-    @SpyBean
+    @MockitoSpyBean
     private ConversationIdService conversationIdService;
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/ConversationIdHeadersTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/ConversationIdHeadersTest.java
@@ -16,6 +16,7 @@ import uk.nhs.digital.nhsconnect.nhais.outbound.fhir.FhirParser;
 import uk.nhs.digital.nhsconnect.nhais.outbound.fhir.FhirToEdifactService;
 import uk.nhs.digital.nhsconnect.nhais.utils.ConversationIdService;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -52,6 +53,7 @@ public class ConversationIdHeadersTest {
 
     @Test
     void When_ConversationNotIdInRequestHeader_Expect_GeneratedIdIsUsed() throws Exception {
+        when(conversationIdService.applyRandomConversationId()).thenCallRealMethod();
         mockMvc.perform(post("/fhir/Patient/$nhais.acceptance")
             .contentType("text/plain")
             .content("qwe"))

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
@@ -10,10 +10,10 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.MeshMessage;
@@ -53,16 +53,16 @@ public class FhirControllerTest {
     @Value("classpath:/patient/parameters.json")
     private Resource paramsPayload;
 
-    @MockBean
+    @MockitoBean
     private OutboundQueueService outboundQueueService;
 
-    @MockBean
+    @MockitoBean
     private FhirToEdifactService fhirToEdifactService;
 
-    @MockBean
+    @MockitoBean
     private FhirParser fhirParser;
 
-    @SpyBean
+    @MockitoSpyBean
     private ConversationIdService conversationIdService;
 
     @Test

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/outbound/controller/FhirControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.nhs.digital.nhsconnect.nhais.mesh.message.MeshMessage;
@@ -62,7 +61,7 @@ public class FhirControllerTest {
     @MockitoBean
     private FhirParser fhirParser;
 
-    @MockitoSpyBean
+    @MockitoBean
     private ConversationIdService conversationIdService;
 
     @Test


### PR DESCRIPTION
* Replace @MockBean with @MockitoBean.
* Replace @SpyBean with @MockitoSpyBean
* The `@MockitoSpyBean` being used in some test files are not being used as spies and causing issues with tests as unable to wrap the bean. The have been replaced these with `@MockitoBean` and tests now run as expected.
* Updated the ConversationIdService to use spring injection into the ConversationIdFilter via parameter injection and have removed the lazyInitialize method.
* Updated ConversationIdFilterConfig to use spring injection rather than instantiating.