### PR TITLE
operationId not set when message is unsolicited

### DIFF
--- a/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundMeshQueueMultiTransactionTest.java
@@ -59,9 +59,7 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
     private static final ReferenceTransactionType.Inbound MESSAGE_2_TRANSACTION_TYPE = ReferenceTransactionType.Inbound.DEDUCTION;
     private static final ReferenceTransactionType.Inbound MESSAGE_3_TRANSACTION_TYPE = ReferenceTransactionType.Inbound.REJECTION;
     private static final ReferenceTransactionType.Inbound MESSAGE_4_TRANSACTION_TYPE = ReferenceTransactionType.Inbound.APPROVAL;
-    private static final String TRANSACTION_1_OPERATION_ID = OperationId.buildOperationId(SENDER, TN_1);
-    private static final String TRANSACTION_2_OPERATION_ID = OperationId.buildOperationId(SENDER, TN_2);
-    private static final String TRANSACTION_3_OPERATION_ID = OperationId.buildOperationId(SENDER, TN_3);
+    private static final String NULL_OPERATION_ID = null;
     private static final String TRANSACTION_4_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_4);
     private static final String TRANSACTION_5_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_5);
     private static final String TRANSACTION_6_OPERATION_ID = OperationId.buildOperationId(RECIPIENT, TN_6);
@@ -168,11 +166,11 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
             .toList();
 
         assertGpSystemInboundQueueMessages(
-            softly, gpSystemInboundQueueMessages.get(TN1_INDEX), MESSAGE_1_TRANSACTION_TYPE, TRANSACTION_1_OPERATION_ID, fhirTN1);
+            softly, gpSystemInboundQueueMessages.get(TN1_INDEX), MESSAGE_1_TRANSACTION_TYPE, NULL_OPERATION_ID, fhirTN1);
         assertGpSystemInboundQueueMessages(
-            softly, gpSystemInboundQueueMessages.get(TN2_INDEX), MESSAGE_2_TRANSACTION_TYPE, TRANSACTION_2_OPERATION_ID, fhirTN2);
+            softly, gpSystemInboundQueueMessages.get(TN2_INDEX), MESSAGE_2_TRANSACTION_TYPE, NULL_OPERATION_ID, fhirTN2);
         assertGpSystemInboundQueueMessages(
-            softly, gpSystemInboundQueueMessages.get(TN3_INDEX), MESSAGE_2_TRANSACTION_TYPE, TRANSACTION_3_OPERATION_ID, fhirTN3);
+            softly, gpSystemInboundQueueMessages.get(TN3_INDEX), MESSAGE_2_TRANSACTION_TYPE, NULL_OPERATION_ID, fhirTN3);
         assertGpSystemInboundQueueMessages(
             softly, gpSystemInboundQueueMessages.get(TN4_INDEX), MESSAGE_3_TRANSACTION_TYPE, TRANSACTION_4_OPERATION_ID, fhirTN4);
         assertGpSystemInboundQueueMessages(
@@ -211,11 +209,11 @@ public class InboundMeshQueueMultiTransactionTest extends IntegrationBaseTest {
         softly.assertThat(inboundStates).hasSize(INBOUND_STATE_EXPECTED_SIZE);
 
         assertInboundState(
-            softly, inboundStates.get(TN1_INDEX), TRANSACTION_1_OPERATION_ID, SMS_1, TN_1, MESSAGE_1_TRANSACTION_TYPE);
+            softly, inboundStates.get(TN1_INDEX), NULL_OPERATION_ID, SMS_1, TN_1, MESSAGE_1_TRANSACTION_TYPE);
         assertInboundState(
-            softly, inboundStates.get(TN2_INDEX), TRANSACTION_2_OPERATION_ID, SMS_2, TN_2, MESSAGE_2_TRANSACTION_TYPE);
+            softly, inboundStates.get(TN2_INDEX), NULL_OPERATION_ID, SMS_2, TN_2, MESSAGE_2_TRANSACTION_TYPE);
         assertInboundState(
-            softly, inboundStates.get(TN3_INDEX), TRANSACTION_3_OPERATION_ID, SMS_2, TN_3, MESSAGE_2_TRANSACTION_TYPE);
+            softly, inboundStates.get(TN3_INDEX), NULL_OPERATION_ID, SMS_2, TN_3, MESSAGE_2_TRANSACTION_TYPE);
         assertInboundState(
             softly, inboundStates.get(TN4_INDEX), TRANSACTION_4_OPERATION_ID, SMS_3, TN_4, MESSAGE_3_TRANSACTION_TYPE);
         assertInboundState(

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdService.java
@@ -21,11 +21,9 @@ public class InboundOperationIdService {
             // inbound transactions matched to the outbound transaction by their transaction number use recipient
             // trading partner code to ensure the same OperationId is generated
             tradingPartnerCode = transaction.getMessage().getInterchange().getInterchangeHeader().getRecipient();
-        } else {
-            // inbound transactions not matched to an outbound transaction by transaction number use sender
-            // trading partner code to ensure the OperationId is unique
-            tradingPartnerCode = transaction.getMessage().getInterchange().getInterchangeHeader().getSender();
+            return OperationId.buildOperationId(tradingPartnerCode, transactionNumber);
         }
-        return OperationId.buildOperationId(tradingPartnerCode, transactionNumber);
+        // inbound transactions that can't be matched to an outbound transaction don't return an OperationId
+        return null;
     }
 }

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemService.java
@@ -32,7 +32,7 @@ public class InboundGpSystemService {
         LOGGER.debug("Encoded FHIR to string: {}", jsonMessage);
         jmsTemplate.send(gpSystemInboundQueueName, session -> {
             var message = session.createTextMessage(jsonMessage);
-            if(dataToSend.getOperationId() != null) {
+            if (dataToSend.getOperationId() != null) {
                 message.setStringProperty(JmsHeaders.OPERATION_ID, dataToSend.getOperationId());
             }
             message.setStringProperty(JmsHeaders.TRANSACTION_TYPE, dataToSend.getTransactionType().name().toLowerCase());

--- a/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemService.java
+++ b/src/main/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemService.java
@@ -32,7 +32,9 @@ public class InboundGpSystemService {
         LOGGER.debug("Encoded FHIR to string: {}", jsonMessage);
         jmsTemplate.send(gpSystemInboundQueueName, session -> {
             var message = session.createTextMessage(jsonMessage);
-            message.setStringProperty(JmsHeaders.OPERATION_ID, dataToSend.getOperationId());
+            if(dataToSend.getOperationId() != null) {
+                message.setStringProperty(JmsHeaders.OPERATION_ID, dataToSend.getOperationId());
+            }
             message.setStringProperty(JmsHeaders.TRANSACTION_TYPE, dataToSend.getTransactionType().name().toLowerCase());
             message.setStringProperty(JmsHeaders.CONVERSATION_ID, conversationIdService.getCurrentConversationId());
             return message;

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/InboundOperationIdServiceTest.java
@@ -50,15 +50,15 @@ public class InboundOperationIdServiceTest {
     private void beforeEach() {
         when(transaction.getMessage()).thenReturn(message);
         when(transaction.getReferenceTransactionNumber()).thenReturn(referenceTransactionNumber);
-        when(message.getInterchange()).thenReturn(interchange);
         when(message.getReferenceTransactionType()).thenReturn(referenceTransactionType);
-        when(interchange.getInterchangeHeader()).thenReturn(interchangeHeader);
         when(referenceTransactionNumber.getTransactionNumber()).thenReturn(TN);
     }
 
     @ParameterizedTest
     @EnumSource(value = ReferenceTransactionType.Inbound.class, names = {"APPROVAL", "REJECTION"})
     public void When_ApprovalOrRejectionTransaction_Expect_OperationIdUsesRecipient(ReferenceTransactionType.Inbound transactionType) {
+        when(message.getInterchange()).thenReturn(interchange);
+        when(interchange.getInterchangeHeader()).thenReturn(interchangeHeader);
         when(referenceTransactionType.getTransactionType()).thenReturn(transactionType);
         when(interchangeHeader.getRecipient()).thenReturn(RECIPIENT);
         assertThat(RECIPIENT_OID).isEqualTo(operationIdService.createOperationIdForTransaction(transaction));
@@ -66,10 +66,9 @@ public class InboundOperationIdServiceTest {
 
     @ParameterizedTest
     @EnumSource(value = ReferenceTransactionType.Inbound.class, names = {"APPROVAL", "REJECTION"}, mode = EnumSource.Mode.EXCLUDE)
-    public void When_AllOtherTransactions_Expect_OperationIdUsesSender(ReferenceTransactionType.Inbound transactionType) {
+    public void When_AllOtherTransactions_Expect_OperationIdNotGenerated(ReferenceTransactionType.Inbound transactionType) {
         when(referenceTransactionType.getTransactionType()).thenReturn(transactionType);
-        when(interchangeHeader.getSender()).thenReturn(SENDER);
-        assertThat(SENDER_OID).isEqualTo(operationIdService.createOperationIdForTransaction(transaction));
+        assertThat(operationIdService.createOperationIdForTransaction(transaction)).isNull();
     }
 
 }

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemServiceTest.java
@@ -19,7 +19,9 @@ import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
 
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 public class InboundGpSystemServiceTest {

--- a/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemServiceTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/nhais/inbound/queue/InboundGpSystemServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jms.core.JmsTemplate;
@@ -18,8 +19,7 @@ import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
 
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class InboundGpSystemServiceTest {
@@ -72,6 +72,37 @@ public class InboundGpSystemServiceTest {
 
         verify(session).createTextMessage(eq(serializedData));
         verify(textMessage).setStringProperty("OperationId", operationId);
+        verify(textMessage).setStringProperty("TransactionType", transactionType.name().toLowerCase());
+        verify(textMessage).setStringProperty("ConversationId", "ABC123");
+    }
+
+    @Test
+    public void testPublishToGpSupplierQueueOmitsOperationIdHeaderWhenNoOperationIdPresent() throws JMSException {
+        Parameters parameters = new Parameters();
+        String operationId = null;
+        ReferenceTransactionType.TransactionType transactionType = ReferenceTransactionType.Outbound.ACCEPTANCE;
+
+        var dataToSend = new InboundGpSystemService.DataToSend()
+                .setOperationId(operationId)
+                .setTransactionType(transactionType)
+                .setContent(parameters);
+
+        String serializedData = "some_serialized_data";
+        when(serializer.serialize(parameters)).thenReturn(serializedData);
+        when(conversationIdService.getCurrentConversationId()).thenReturn("ABC123");
+
+        inboundGpSystemService.publishToSupplierQueue(dataToSend);
+
+        var messageCreatorArgumentCaptor = ArgumentCaptor.forClass(MessageCreator.class);
+
+        verify(jmsTemplate).send(eq(gpSystemInboundQueueName), messageCreatorArgumentCaptor.capture());
+
+        when(session.createTextMessage(serializedData)).thenReturn(textMessage);
+
+        messageCreatorArgumentCaptor.getValue().createMessage(session);
+
+        verify(session).createTextMessage(eq(serializedData));
+        verify(textMessage, never()).setStringProperty(eq("OperationId"), Mockito.anyString());
         verify(textMessage).setStringProperty("TransactionType", transactionType.name().toLowerCase());
         verify(textMessage).setStringProperty("ConversationId", "ABC123");
     }


### PR DESCRIPTION
## What

Remove OperationId from header when incoming message is unsolicited

## Why

When an incoming message is unsolicited, an operationId is generated but doesn't actually have any correlation to anything in the system.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](../CHANGELOG.MD) with details of my change in the UNRELEASED section if this change will affect end users